### PR TITLE
Align C unpack_u64_dyn_v2 with Lua behavior

### DIFF
--- a/c/test.c
+++ b/c/test.c
@@ -20,8 +20,8 @@ int main()
 			{ 0x80, "\x80\x00", 2 },
 			{ 1337, "\xB9\x09", 2 },
 			{ 42069, "\xD5\xC7\x01", 3 },
-			{ 0xffffffffffffffff, "\xFF\xFE\xFE\xFE\xFE\xFE\xFE\xFE\xFE", 9 },
-			//{ 0x8000000000000000, "\x80\xFF\xFE\xFE\xFE\xFE\xFE\xFE\x7E", 9 },
+                        { 0xffffffffffffffff, "\xFF\xFE\xFE\xFE\xFE\xFE\xFE\xFE\xFE", 9 },
+                        { 0x8000000000000000, "\x80\xFF\xFE\xFE\xFE\xFE\xFE\xFE\x7E", 9 },
 		};
 		for (size_t i = 0; i != COUNT(pairs); ++i)
 		{

--- a/c/test.c
+++ b/c/test.c
@@ -11,45 +11,45 @@ struct IPair { int64_t v; const char* d; size_t s; };
 
 int main()
 {
-	uint8_t data[9];
-	size_t out_size;
-	{
-		struct UPair pairs[] = {
-			{ 0, "\x00", 1 },
-			{ 0x7f, "\x7F", 1 },
-			{ 0x80, "\x80\x00", 2 },
-			{ 1337, "\xB9\x09", 2 },
-			{ 42069, "\xD5\xC7\x01", 3 },
-                        { 0xffffffffffffffff, "\xFF\xFE\xFE\xFE\xFE\xFE\xFE\xFE\xFE", 9 },
-                        { 0x8000000000000000, "\x80\xFF\xFE\xFE\xFE\xFE\xFE\xFE\x7E", 9 },
-		};
-		for (size_t i = 0; i != COUNT(pairs); ++i)
-		{
-			const struct UPair* pair = &pairs[i];
-			//printf("%llu\n", pair->v);
-			assert(pack_u64_dyn_v2(data, pair->v) == pair->s);
-			assert(memcmp(data, pair->d, pair->s) == 0);
-			assert(unpack_u64_dyn_v2(data, pair->s, &out_size) == pair->v);
-		}
-	}
-	{
-		struct IPair pairs[] = {
-			{ 0, "\x00", 1 },
-			{ 0x7f, "\xBF\x00", 2 },
-			{ 0x80, "\x80\x01", 2 },
-			{ 1337, "\xB9\x13", 2 },
-			{ 42069, "\x95\x90\x04", 3 },
-			//{ -1, "\x40", 1 },
-			{ INT64_MIN, "\xFF\xFE\xFE\xFE\xFE\xFE\xFE\xFE\xFE", 9 },
-		};
-		for (size_t i = 0; i != COUNT(pairs); ++i)
-		{
-			const struct IPair* pair = &pairs[i];
-			//printf("%lli\n", pair->v);
-			assert(pack_i64_dyn_v2(data, pair->v) == pair->s);
-			assert(memcmp(data, pair->d, pair->s) == 0);
-			assert(unpack_i64_dyn_v2(data, pair->s, &out_size) == pair->v);
-		}
-	}
-	return 0;
+    uint8_t data[9];
+    size_t out_size;
+    {
+        struct UPair pairs[] = {
+            { 0, "\x00", 1 },
+            { 0x7f, "\x7F", 1 },
+            { 0x80, "\x80\x00", 2 },
+            { 1337, "\xB9\x09", 2 },
+            { 42069, "\xD5\xC7\x01", 3 },
+            { 0xffffffffffffffff, "\xFF\xFE\xFE\xFE\xFE\xFE\xFE\xFE\xFE", 9 },
+            { 0x8000000000000000, "\x80\xFF\xFE\xFE\xFE\xFE\xFE\xFE\x7E", 9 },
+        };
+        for (size_t i = 0; i != COUNT(pairs); ++i)
+        {
+            const struct UPair* pair = &pairs[i];
+            //printf("%llu\n", pair->v);
+            assert(pack_u64_dyn_v2(data, pair->v) == pair->s);
+            assert(memcmp(data, pair->d, pair->s) == 0);
+            assert(unpack_u64_dyn_v2(data, pair->s, &out_size) == pair->v);
+        }
+    }
+    {
+        struct IPair pairs[] = {
+            { 0, "\x00", 1 },
+            { 0x7f, "\xBF\x00", 2 },
+            { 0x80, "\x80\x01", 2 },
+            { 1337, "\xB9\x13", 2 },
+            { 42069, "\x95\x90\x04", 3 },
+            //{ -1, "\x40", 1 },
+            { INT64_MIN, "\xFF\xFE\xFE\xFE\xFE\xFE\xFE\xFE\xFE", 9 },
+        };
+        for (size_t i = 0; i != COUNT(pairs); ++i)
+        {
+            const struct IPair* pair = &pairs[i];
+            //printf("%lli\n", pair->v);
+            assert(pack_i64_dyn_v2(data, pair->v) == pair->s);
+            assert(memcmp(data, pair->d, pair->s) == 0);
+            assert(unpack_i64_dyn_v2(data, pair->s, &out_size) == pair->v);
+        }
+    }
+    return 0;
 }

--- a/c/u64_dyn.c
+++ b/c/u64_dyn.c
@@ -27,32 +27,44 @@ size_t pack_u64_dyn_v2(uint8_t out[9], uint64_t v)
 
 uint64_t unpack_u64_dyn_v2(const uint8_t* in_data, size_t in_size, size_t* out_size)
 {
-	uint64_t v = 0;
-	int bits = 0;
-	if (in_size)
-	{
-		uint8_t b = *in_data;
-		v = b & 0x7f;
-		int has_next = b >> 7;
-		bits += 7;
-		while (has_next && (++in_data, --in_size))
-		{
-			b = *in_data;
-			has_next = 0;
-			if (bits < 56)
-			{
-				has_next = *in_data >> 7;
-				b &= 0x7f;
-			}
-			v = v | ((b + 1) << bits);
-			bits += 7;
-		}
-	}
-	if (out_size)
-	{
-		*out_size = bits / 7;
-	}
-	return v;
+        uint64_t v = 0;
+        int bits = 0;
+        size_t used = 0;
+
+        /*
+         * This decoding mirrors the Lua reference implementation found in
+         * lua/u64_dyn.lua.  Each byte contributes seven value bits and, when
+         * the continuation flag (bit 7) is set, the encoded value is biased by
+         * 1 << bits (where bits is the number of value bits accumulated so
+         * far).  After eight bytes the ninth byte, if present, contributes the
+         * remaining eight bits without the bias/continuation flag.
+         */
+
+        /* Process at most eight bytes with continuation bits. */
+        while (used < in_size && used < 8)
+        {
+                uint8_t b = in_data[used++];
+                v += (uint64_t)(b & 0x7f) << bits;
+                if ((b & 0x80) == 0)
+                        goto done;
+                bits += 7;
+                v += (uint64_t)1 << bits; /* v2 bias */
+        }
+
+        /* If we consumed eight bytes and still have data, the ninth byte
+         * contributes the upper 8 bits directly. */
+        if (used < in_size)
+        {
+                uint8_t b = in_data[used++];
+                v += (uint64_t)b << 56;
+        }
+
+done:
+        if (out_size)
+        {
+                *out_size = used;
+        }
+        return v;
 }
 
 size_t pack_i64_dyn_v2(uint8_t out[9], int64_t v)

--- a/c/u64_dyn.c
+++ b/c/u64_dyn.c
@@ -2,69 +2,56 @@
 
 size_t pack_u64_dyn_v2(uint8_t out[9], uint64_t v)
 {
-	size_t i = 0;
-	while (i != 8)
-	{
-		const uint8_t cur = v & 0x7f;
-		v >>= 7;
-		if (v != 0)
-		{
-			out[i++] = cur | 0x80;
-			v -= 1; // v2
-		}
-		else
-		{
-			out[i++] = cur;
-			return i;
-		}
-	}
-	if (v != 0)
-	{
-		out[i++] = v;
-	}
-	return i;
+    size_t i = 0;
+    while (i != 8)
+    {
+        const uint8_t cur = v & 0x7f;
+        v >>= 7;
+        if (v != 0)
+        {
+            out[i++] = cur | 0x80;
+            v -= 1; // v2
+        }
+        else
+        {
+            out[i++] = cur;
+            return i;
+        }
+    }
+    if (v != 0)
+    {
+        out[i++] = v;
+    }
+    return i;
 }
 
 uint64_t unpack_u64_dyn_v2(const uint8_t* in_data, size_t in_size, size_t* out_size)
 {
-        uint64_t v = 0;
-        int bits = 0;
-        size_t used = 0;
-
-        /*
-         * This decoding mirrors the Lua reference implementation found in
-         * lua/u64_dyn.lua.  Each byte contributes seven value bits and, when
-         * the continuation flag (bit 7) is set, the encoded value is biased by
-         * 1 << bits (where bits is the number of value bits accumulated so
-         * far).  After eight bytes the ninth byte, if present, contributes the
-         * remaining eight bits without the bias/continuation flag.
-         */
-
-        /* Process at most eight bytes with continuation bits. */
-        while (used < in_size && used < 8)
+    uint64_t v = 0;
+    int bits = 0;
+    size_t used = 0;
+    while (used < in_size && used < 8)
+    {
+        uint8_t b = in_data[used++];
+        v += (uint64_t)(b & 0x7f) << bits;
+        if ((b & 0x80) == 0)
         {
-                uint8_t b = in_data[used++];
-                v += (uint64_t)(b & 0x7f) << bits;
-                if ((b & 0x80) == 0)
-                        goto done;
-                bits += 7;
-                v += (uint64_t)1 << bits; /* v2 bias */
+            goto done;
         }
-
-        /* If we consumed eight bytes and still have data, the ninth byte
-         * contributes the upper 8 bits directly. */
-        if (used < in_size)
-        {
-                uint8_t b = in_data[used++];
-                v += (uint64_t)b << 56;
-        }
-
-done:
-        if (out_size)
-        {
-                *out_size = used;
-        }
-        return v;
+        bits += 7;
+        v += (uint64_t)1 << bits;
+    }
+    if (used < in_size)
+    {
+        uint8_t b = in_data[used++];
+        v += (uint64_t)b << 56;
+    }
+  done:
+    if (out_size)
+    {
+        *out_size = used;
+    }
+    return v;
 }
 
 size_t pack_i64_dyn_v2(uint8_t out[9], int64_t v)
@@ -79,13 +66,13 @@ size_t pack_i64_dyn_v2(uint8_t out[9], int64_t v)
     {
         u = v;
     }
-	return pack_u64_dyn_v2(out, (neg << 6) | ((u & ~0x3f) << 1) | (u & 0x3f));
+    return pack_u64_dyn_v2(out, (neg << 6) | ((u & ~0x3f) << 1) | (u & 0x3f));
 }
 
 int64_t unpack_i64_dyn_v2(const uint8_t* in_data, size_t in_size, size_t* out_size)
 {
-	uint64_t u = unpack_u64_dyn_v2(in_data, in_size, out_size);
-	const int neg = (u >> 6) & 1; // check bit 6
+    uint64_t u = unpack_u64_dyn_v2(in_data, in_size, out_size);
+    const int neg = (u >> 6) & 1; // check bit 6
     u = ((u >> 1) & ~0x3f) | (u & 0x3f); // remove bit 6
     int64_t v;
     if (neg)


### PR DESCRIPTION
## Summary
- Reimplement unpack_u64_dyn_v2 to mirror Lua reference, accumulating value bits with the v2 bias and supporting a ninth byte
- Re-enable test for decoding 0x8000000000000000 using the updated routine

## Testing
- `gcc c/test.c c/u64_dyn.c -o test && ./test`


------
https://chatgpt.com/codex/tasks/task_e_6898e2028b108325bd2b5d513961efd5