### PR TITLE
Fix PHP unpacking for 0x8000000000000000

### DIFF
--- a/php/u64_dyn.php
+++ b/php/u64_dyn.php
@@ -72,8 +72,8 @@ $tests_u64 = [
     0x80 => "\x80\x00",
     1337 => "\xB9\x09",
     42069 => "\xD5\xC7\x01",
-    /*0xffffffffffffffff*/ -1 => "\xFF\xFE\xFE\xFE\xFE\xFE\xFE\xFE\xFE",
-    /*0x8000000000000000*/ ((-1) << 63) => "\x80\xFF\xFE\xFE\xFE\xFE\xFE\xFE\x7E",
+    -1 => "\xFF\xFE\xFE\xFE\xFE\xFE\xFE\xFE\xFE",
+    -9223372036854775808 => "\x80\xFF\xFE\xFE\xFE\xFE\xFE\xFE\x7E",
 ];
 
 foreach ($tests_u64 as $val => $enc)

--- a/php/u64_dyn.php
+++ b/php/u64_dyn.php
@@ -28,25 +28,40 @@ function pack_u64_dyn_v2($v)
     return $out;
 }
 
+function add64($a, $b)
+{
+    $mask = -1;
+    while ($b != 0)
+    {
+        $carry = ($a & $b) << 1;
+        $a = ($a ^ $b) & $mask;
+        $b = $carry & $mask;
+    }
+    return $a;
+}
+
 function unpack_u64_dyn_v2($str)
 {
-    $b = ord($str[0]);
-    $v = $b & 0x7f;
-    $i = 1;
-    $bits = 7;
-    $has_next = ($b >> 7) != 0;
-    while ($has_next)
+    $len = strlen($str);
+    $v = 0;
+    $bits = 0;
+    $i = 0;
+    while ($i < $len && $i < 8)
     {
         $b = ord($str[$i]);
         $i++;
-        $has_next = false;
-        if ($bits < 56)
+        $v = add64($v, ($b & 0x7f) << $bits);
+        if (($b & 0x80) == 0)
         {
-            $has_next = ($b >> 7) != 0;
-            $b = $b & 0x7f;
+            return $v;
         }
-        $v |= (($b + 1) << $bits);
         $bits += 7;
+        $v = add64($v, 1 << $bits);
+    }
+    if ($i < $len)
+    {
+        $b = ord($str[$i]);
+        $v = add64($v, $b << 56);
     }
     return $v;
 }
@@ -58,6 +73,7 @@ $tests_u64 = [
     1337 => "\xB9\x09",
     42069 => "\xD5\xC7\x01",
     /*0xffffffffffffffff*/ -1 => "\xFF\xFE\xFE\xFE\xFE\xFE\xFE\xFE\xFE",
+    /*0x8000000000000000*/ ((-1) << 63) => "\x80\xFF\xFE\xFE\xFE\xFE\xFE\xFE\x7E",
 ];
 
 foreach ($tests_u64 as $val => $enc)


### PR DESCRIPTION
## Summary
- implement 64-bit addition using bitwise operations to avoid bcmath/gmp
- decode u64 values with native integer math and keep coverage for the 0x8000000000000000 edge case

## Testing
- `php php/u64_dyn.php`


------
https://chatgpt.com/codex/tasks/task_e_6898e601067883258375570bbb16c6b6