### PR TITLE
Add i64_dyn v1 encoding to C implementation

### DIFF
--- a/c/test.c
+++ b/c/test.c
@@ -54,6 +54,24 @@ int main()
     {
         struct IPair pairs[] = {
             { 0, "\x00", 1 },
+            { 0x7f, "\xBF\x01", 2 },
+            { 0x80, "\x80\x02", 2 },
+            { 1337, "\xB9\x14", 2 },
+            { 42069, "\x95\x91\x05", 3 },
+            { -1, "\x41", 1 },
+            { INT64_MIN, "\x40", 1 },
+        };
+        for (size_t i = 0; i != COUNT(pairs); ++i)
+        {
+            const struct IPair* pair = &pairs[i];
+            assert(pack_i64_dyn(data, pair->v) == pair->s);
+            assert(memcmp(data, pair->d, pair->s) == 0);
+            assert(unpack_i64_dyn(data, pair->s, &out_size) == pair->v);
+        }
+    }
+    {
+        struct IPair pairs[] = {
+            { 0, "\x00", 1 },
             { 0x7f, "\xBF\x00", 2 },
             { 0x80, "\x80\x01", 2 },
             { 1337, "\xB9\x13", 2 },

--- a/c/u64_dyn.c
+++ b/c/u64_dyn.c
@@ -106,6 +106,33 @@ uint64_t unpack_u64_dyn_v2(const uint8_t* in_data, size_t in_size, size_t* out_s
     return v;
 }
 
+size_t pack_i64_dyn(uint8_t out[9], int64_t v)
+{
+    uint64_t u = (uint64_t)v;
+    uint64_t neg = (uint64_t)(v < 0);
+    if (neg)
+    {
+        u = (~u + 1) & ~((uint64_t)1 << 63);
+    }
+    return pack_u64_dyn(out, (neg << 6) | ((u & ~0x3f) << 1) | (u & 0x3f));
+}
+
+int64_t unpack_i64_dyn(const uint8_t* in_data, size_t in_size, size_t* out_size)
+{
+    uint64_t u = unpack_u64_dyn(in_data, in_size, out_size);
+    const int neg = (u >> 6) & 1;
+    u = ((u >> 1) & ~((uint64_t)0x3f)) | (u & 0x3f);
+    if (neg)
+    {
+        if (u == 0)
+        {
+            return (int64_t)1 << 63;
+        }
+        return -(int64_t)u;
+    }
+    return (int64_t)u;
+}
+
 size_t pack_i64_dyn_v2(uint8_t out[9], int64_t v)
 {
     uint64_t u;

--- a/c/u64_dyn.h
+++ b/c/u64_dyn.h
@@ -8,6 +8,8 @@ size_t pack_u64_dyn(uint8_t out[9], uint64_t v);
 uint64_t unpack_u64_dyn(const uint8_t* in_data, size_t in_size, size_t* out_size);
 size_t pack_u64_dyn_v2(uint8_t out[9], uint64_t v);
 uint64_t unpack_u64_dyn_v2(const uint8_t* in_data, size_t in_size, size_t* out_size);
+size_t pack_i64_dyn(uint8_t out[9], int64_t v);
+int64_t unpack_i64_dyn(const uint8_t* in_data, size_t in_size, size_t* out_size);
 size_t pack_i64_dyn_v2(uint8_t out[9], int64_t v);
 int64_t unpack_i64_dyn_v2(const uint8_t* in_data, size_t in_size, size_t* out_size);
 


### PR DESCRIPTION
## Summary
- implement pack/unpack for i64_dyn (v1) in C
- test signed 64-bit variable-length encoding

## Testing
- `gcc c/test.c c/u64_dyn.c -o c/test && ./c/test`


------
https://chatgpt.com/codex/tasks/task_e_6898ea226d248325b1bb32f1a389257d