### PR TITLE
Add workflows for C, Lua, and PHP tests

### DIFF
--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -1,0 +1,15 @@
+name: C
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build and run tests
+        run: |
+          gcc c/test.c c/u64_dyn.c -o c/test
+          ./c/test

--- a/.github/workflows/lua.yml
+++ b/.github/workflows/lua.yml
@@ -6,12 +6,8 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: debian-10
     steps:
       - uses: actions/checkout@v4
-      - name: Install Lua
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y lua5.4
       - name: Run tests
         run: lua lua/u64_dyn.lua

--- a/.github/workflows/lua.yml
+++ b/.github/workflows/lua.yml
@@ -1,0 +1,17 @@
+name: Lua
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Lua
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y lua5.4
+      - name: Run tests
+        run: lua lua/u64_dyn.lua

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,0 +1,13 @@
+name: PHP
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests
+        run: php php/u64_dyn.php


### PR DESCRIPTION
## Summary
- add GitHub Action for building and running C tests
- add Lua workflow that installs Lua and runs its assertions
- add PHP workflow to execute embedded tests

## Testing
- `gcc c/test.c c/u64_dyn.c -o c/test && ./c/test`
- `php php/u64_dyn.php`
- `lua lua/u64_dyn.lua` *(fails: command not found)*
- `sudo apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6898f02e43b08325b821ef13a858273f