### PR TITLE
Fix i64_dyn_v2 negative handling for -1

### DIFF
--- a/c/test.c
+++ b/c/test.c
@@ -76,7 +76,7 @@ int main()
             { 0x80, "\x80\x01", 2 },
             { 1337, "\xB9\x13", 2 },
             { 42069, "\x95\x90\x04", 3 },
-            //{ -1, "\x40", 1 },
+            { -1, "\x40", 1 },
             { INT64_MIN, "\xFF\xFE\xFE\xFE\xFE\xFE\xFE\xFE\xFE", 9 },
         };
         for (size_t i = 0; i != COUNT(pairs); ++i)

--- a/c/u64_dyn.c
+++ b/c/u64_dyn.c
@@ -135,32 +135,24 @@ int64_t unpack_i64_dyn(const uint8_t* in_data, size_t in_size, size_t* out_size)
 
 size_t pack_i64_dyn_v2(uint8_t out[9], int64_t v)
 {
-    uint64_t u;
-    uint64_t neg = (v >> 63);
+    uint64_t u = (uint64_t)v;
+    uint64_t neg = (uint64_t)(v < 0);
     if (neg)
     {
-        u = ~v;
+        u = ~u;
     }
-    else
-    {
-        u = v;
-    }
-    return pack_u64_dyn_v2(out, (neg << 6) | ((u & ~0x3f) << 1) | (u & 0x3f));
+    return pack_u64_dyn_v2(out, (neg << 6) | ((u & ~0x3fULL) << 1) | (u & 0x3fULL));
 }
 
 int64_t unpack_i64_dyn_v2(const uint8_t* in_data, size_t in_size, size_t* out_size)
 {
     uint64_t u = unpack_u64_dyn_v2(in_data, in_size, out_size);
-    const int neg = (u >> 6) & 1; // check bit 6
-    u = ((u >> 1) & ~0x3f) | (u & 0x3f); // remove bit 6
-    int64_t v;
+    const uint64_t neg = (u >> 6) & 1; // check bit 6
+    u = ((u >> 1) & ~0x3fULL) | (u & 0x3fULL); // remove bit 6
+    int64_t v = (int64_t)u;
     if (neg)
     {
-        v = ~u;
-    }
-    else
-    {
-        v = u;
+        v = -v - 1;
     }
     return v;
 }


### PR DESCRIPTION
## Summary
- handle negative values in `i64_dyn_v2` with proper sign detection and decoding
- re-enable `-1` test for `i64_dyn_v2`

## Testing
- `gcc -std=c99 -Wall -Wextra -pedantic c/test.c c/u64_dyn.c && ./a.out && echo OK`


------
https://chatgpt.com/codex/tasks/task_e_68990b9386ac83259b78a4d72d0ca942