### PR TITLE
Add i64_dyn support in PHP implementation

### DIFF
--- a/php/test.php
+++ b/php/test.php
@@ -39,6 +39,24 @@ foreach ($tests_u64 as $val => $enc)
 
 $tests_i64 = [
     0 => "\x00",
+    0x7f => "\xBF\x01",
+    0x80 => "\x80\x02",
+    1337 => "\xB9\x14",
+    42069 => "\x95\x91\x05",
+    -1 => "\x41",
+    PHP_INT_MIN => "\x40",
+];
+
+foreach ($tests_i64 as $val => $enc)
+{
+    assert(pack_i64_dyn($val) == $enc);
+    $offset = 0;
+    assert(unpack_i64_dyn($enc, $offset) == $val);
+    assert($offset == strlen($enc));
+}
+
+$tests_i64 = [
+    0 => "\x00",
     0x7f => "\xBF\x00",
     0x80 => "\x80\x01",
     1337 => "\xB9\x13",

--- a/php/u64_dyn.php
+++ b/php/u64_dyn.php
@@ -125,6 +125,46 @@ function unpack_u64_dyn_v2($str, &$offset = 0)
     return $v;
 }
 
+function pack_i64_dyn($v)
+{
+    if (is_float($v))
+    {
+        throw new Exception("Cannot encode a float as i64");
+    }
+    $neg = ($v >> 63) & 1;
+    if ($v < 0)
+    {
+        $u = add64(~$v, 1);
+        $u &= ~(-1 << 63);
+    }
+    else
+    {
+        $u = $v;
+    }
+    return pack_u64_dyn(($neg << 6) | (($u & ~0x3f) << 1) | ($u & 0x3f));
+}
+
+function unpack_i64_dyn($str, &$offset = 0)
+{
+    $v = unpack_u64_dyn($str, $offset);
+    $neg = (($v >> 6) & 1) != 0;
+    $upper = $v & ~0x7f;
+    $upper = ($upper >> 1) & ~(-1 << 63);
+    $v = $upper | ($v & 0x3f);
+    if ($neg)
+    {
+        if ($v == 0)
+        {
+            $v = PHP_INT_MIN;
+        }
+        else
+        {
+            $v = -$v;
+        }
+    }
+    return $v;
+}
+
 function pack_i64_dyn_v2($v)
 {
     if (is_float($v))


### PR DESCRIPTION
## Summary
- implement pack_i64_dyn and unpack_i64_dyn for PHP
- extend PHP test suite with coverage for i64_dyn encoding/decoding

## Testing
- `php php/test.php`


------
https://chatgpt.com/codex/tasks/task_e_68990c2919b48325acb19c53e296ff89