### PR TITLE
Throw on truncated input for JS unpackers

### DIFF
--- a/js/test.js
+++ b/js/test.js
@@ -72,3 +72,18 @@ for (const [val, enc] of casesI64v2) {
   const [value, off] = unpack_i64_dyn_v2(Uint8Array.from(enc));
   console.assert(value === BigInt.asIntN(64, val) && off === enc.length, 'unpack_i64_dyn_v2 mismatch', val);
 }
+
+function expectThrow(fn, msg) {
+  let threw = false;
+  try {
+    fn();
+  } catch (e) {
+    threw = true;
+  }
+  console.assert(threw, msg);
+}
+
+expectThrow(() => unpack_u64_dyn(Uint8Array.from([0x80])), 'unpack_u64_dyn should throw on insufficient data');
+expectThrow(() => unpack_u64_dyn_v2(Uint8Array.from([0x80])), 'unpack_u64_dyn_v2 should throw on insufficient data');
+expectThrow(() => unpack_i64_dyn(Uint8Array.from([0x80])), 'unpack_i64_dyn should throw on insufficient data');
+expectThrow(() => unpack_i64_dyn_v2(Uint8Array.from([0x80])), 'unpack_i64_dyn_v2 should throw on insufficient data');

--- a/js/test.js
+++ b/js/test.js
@@ -83,7 +83,16 @@ function expectThrow(fn, msg) {
   console.assert(threw, msg);
 }
 
-expectThrow(() => unpack_u64_dyn(Uint8Array.from([0x80])), 'unpack_u64_dyn should throw on insufficient data');
-expectThrow(() => unpack_u64_dyn_v2(Uint8Array.from([0x80])), 'unpack_u64_dyn_v2 should throw on insufficient data');
-expectThrow(() => unpack_i64_dyn(Uint8Array.from([0x80])), 'unpack_i64_dyn should throw on insufficient data');
-expectThrow(() => unpack_i64_dyn_v2(Uint8Array.from([0x80])), 'unpack_i64_dyn_v2 should throw on insufficient data');
+const truncatedCases = [
+  [],
+  [0x80],
+  [0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80]
+];
+
+for (const enc of truncatedCases) {
+  const buf = Uint8Array.from(enc);
+  expectThrow(() => unpack_u64_dyn(buf), 'unpack_u64_dyn should throw on insufficient data');
+  expectThrow(() => unpack_i64_dyn(buf), 'unpack_i64_dyn should throw on insufficient data');
+  expectThrow(() => unpack_i64_dyn_v2(buf), 'unpack_i64_dyn_v2 should throw on insufficient data');
+  expectThrow(() => unpack_u64_dyn_v2(buf), 'unpack_u64_dyn_v2 should throw on insufficient data');
+}

--- a/js/u64_dyn.js
+++ b/js/u64_dyn.js
@@ -23,19 +23,19 @@ function unpack_u64_dyn(buf, offset = 0) {
   let v = 0n;
   let bits = 0n;
   let used = 0;
-  while (offset + used < buf.length && used < 8) {
-    const b = BigInt(buf[offset + used++]);
+  for (; used < 8; used++) {
+    if (offset + used >= buf.length) throw new RangeError('Insufficient data');
+    const b = BigInt(buf[offset + used]);
     v += (b & 0x7fn) << bits;
     if ((b & 0x80n) === 0n) {
-      return [v, offset + used];
+      return [v, offset + used + 1];
     }
     bits += 7n;
   }
-  if (offset + used < buf.length) {
-    const b = BigInt(buf[offset + used++]);
-    v += b << 56n;
-  }
-  return [v, offset + used];
+  if (offset + used >= buf.length) throw new RangeError('Insufficient data');
+  const b = BigInt(buf[offset + used]);
+  v += b << 56n;
+  return [v, offset + used + 1];
 }
 
 function pack_u64_dyn_v2(v) {
@@ -62,20 +62,20 @@ function unpack_u64_dyn_v2(buf, offset = 0) {
   let v = 0n;
   let bits = 0n;
   let used = 0;
-  while (offset + used < buf.length && used < 8) {
-    const b = BigInt(buf[offset + used++]);
+  for (; used < 8; used++) {
+    if (offset + used >= buf.length) throw new RangeError('Insufficient data');
+    const b = BigInt(buf[offset + used]);
     v += (b & 0x7fn) << bits;
     if ((b & 0x80n) === 0n) {
-      return [v, offset + used];
+      return [v, offset + used + 1];
     }
     bits += 7n;
     v += 1n << bits;
   }
-  if (offset + used < buf.length) {
-    const b = BigInt(buf[offset + used++]);
-    v += b << 56n;
-  }
-  return [v, offset + used];
+  if (offset + used >= buf.length) throw new RangeError('Insufficient data');
+  const b = BigInt(buf[offset + used]);
+  v += b << 56n;
+  return [v, offset + used + 1];
 }
 
 function pack_i64_dyn(v) {


### PR DESCRIPTION
## Summary
- Throw a `RangeError` when JS unpackers encounter truncated buffers to mirror Lua's behavior
- Add regression tests covering insufficient data cases

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68990d27ab8483258e703b2bc57ea750