### PR TITLE
Add errno-based error handling for C decoder

### DIFF
--- a/c/test.c
+++ b/c/test.c
@@ -14,6 +14,7 @@ int main()
 {
     uint8_t data[9];
     size_t out_size;
+    errno = 0;
     {
         struct UPair pairs[] = {
             { 0, "\x00", 1 },
@@ -28,11 +29,9 @@ int main()
         {
             const struct UPair* pair = &pairs[i];
             //printf("%llu\n", pair->v);
-            errno = 0;
             assert(pack_u64_dyn_v2(data, pair->v) == pair->s);
             assert(errno == 0);
             assert(memcmp(data, pair->d, pair->s) == 0);
-            errno = 0;
             assert(unpack_u64_dyn_v2(data, pair->s, &out_size) == pair->v);
             assert(errno == 0);
         }
@@ -51,11 +50,9 @@ int main()
         {
             const struct UPair* pair = &pairs[i];
             //printf("%llu\n", pair->v);
-            errno = 0;
             assert(pack_u64_dyn(data, pair->v) == pair->s);
             assert(errno == 0);
             assert(memcmp(data, pair->d, pair->s) == 0);
-            errno = 0;
             assert(unpack_u64_dyn(data, pair->s, &out_size) == pair->v);
             assert(errno == 0);
         }
@@ -73,11 +70,9 @@ int main()
         for (size_t i = 0; i != COUNT(pairs); ++i)
         {
             const struct IPair* pair = &pairs[i];
-            errno = 0;
             assert(pack_i64_dyn(data, pair->v) == pair->s);
             assert(errno == 0);
             assert(memcmp(data, pair->d, pair->s) == 0);
-            errno = 0;
             assert(unpack_i64_dyn(data, pair->s, &out_size) == pair->v);
             assert(errno == 0);
         }
@@ -96,11 +91,9 @@ int main()
         {
             const struct IPair* pair = &pairs[i];
             //printf("%lli\n", pair->v);
-            errno = 0;
             assert(pack_i64_dyn_v2(data, pair->v) == pair->s);
             assert(errno == 0);
             assert(memcmp(data, pair->d, pair->s) == 0);
-            errno = 0;
             assert(unpack_i64_dyn_v2(data, pair->s, &out_size) == pair->v);
             assert(errno == 0);
         }

--- a/c/test.c
+++ b/c/test.c
@@ -2,6 +2,7 @@
 
 #include <assert.h>
 #include <string.h> // memcmp
+#include <errno.h>
 //#include <stdio.h>
 
 struct UPair { uint64_t v; const char* d; size_t s; };
@@ -87,6 +88,32 @@ int main()
             assert(memcmp(data, pair->d, pair->s) == 0);
             assert(unpack_i64_dyn_v2(data, pair->s, &out_size) == pair->v);
         }
+    }
+    {
+        uint8_t incomplete[] = { 0x80 };
+        errno = 0;
+        out_size = 123;
+        assert(unpack_u64_dyn(incomplete, 1, &out_size) == 0);
+        assert(errno == EINVAL);
+        assert(out_size == 0);
+
+        errno = 0;
+        out_size = 123;
+        assert(unpack_u64_dyn_v2(incomplete, 1, &out_size) == 0);
+        assert(errno == EINVAL);
+        assert(out_size == 0);
+
+        errno = 0;
+        out_size = 123;
+        assert(unpack_i64_dyn(incomplete, 1, &out_size) == 0);
+        assert(errno == EINVAL);
+        assert(out_size == 0);
+
+        errno = 0;
+        out_size = 123;
+        assert(unpack_i64_dyn_v2(incomplete, 1, &out_size) == 0);
+        assert(errno == EINVAL);
+        assert(out_size == 0);
     }
     return 0;
 }

--- a/c/test.c
+++ b/c/test.c
@@ -28,9 +28,13 @@ int main()
         {
             const struct UPair* pair = &pairs[i];
             //printf("%llu\n", pair->v);
+            errno = 0;
             assert(pack_u64_dyn_v2(data, pair->v) == pair->s);
+            assert(errno == 0);
             assert(memcmp(data, pair->d, pair->s) == 0);
+            errno = 0;
             assert(unpack_u64_dyn_v2(data, pair->s, &out_size) == pair->v);
+            assert(errno == 0);
         }
     }
     {
@@ -47,9 +51,13 @@ int main()
         {
             const struct UPair* pair = &pairs[i];
             //printf("%llu\n", pair->v);
+            errno = 0;
             assert(pack_u64_dyn(data, pair->v) == pair->s);
+            assert(errno == 0);
             assert(memcmp(data, pair->d, pair->s) == 0);
+            errno = 0;
             assert(unpack_u64_dyn(data, pair->s, &out_size) == pair->v);
+            assert(errno == 0);
         }
     }
     {
@@ -65,9 +73,13 @@ int main()
         for (size_t i = 0; i != COUNT(pairs); ++i)
         {
             const struct IPair* pair = &pairs[i];
+            errno = 0;
             assert(pack_i64_dyn(data, pair->v) == pair->s);
+            assert(errno == 0);
             assert(memcmp(data, pair->d, pair->s) == 0);
+            errno = 0;
             assert(unpack_i64_dyn(data, pair->s, &out_size) == pair->v);
+            assert(errno == 0);
         }
     }
     {
@@ -84,9 +96,13 @@ int main()
         {
             const struct IPair* pair = &pairs[i];
             //printf("%lli\n", pair->v);
+            errno = 0;
             assert(pack_i64_dyn_v2(data, pair->v) == pair->s);
+            assert(errno == 0);
             assert(memcmp(data, pair->d, pair->s) == 0);
+            errno = 0;
             assert(unpack_i64_dyn_v2(data, pair->s, &out_size) == pair->v);
+            assert(errno == 0);
         }
     }
     {

--- a/c/u64_dyn.c
+++ b/c/u64_dyn.c
@@ -1,4 +1,5 @@
 #include "u64_dyn.h"
+#include <errno.h>
 
 size_t pack_u64_dyn(uint8_t out[9], uint64_t v)
 {
@@ -26,12 +27,22 @@ size_t pack_u64_dyn(uint8_t out[9], uint64_t v)
 
 uint64_t unpack_u64_dyn(const uint8_t* in_data, size_t in_size, size_t* out_size)
 {
+    if (in_size == 0)
+    {
+        errno = EINVAL;
+        if (out_size)
+        {
+            *out_size = 0;
+        }
+        return 0;
+    }
     uint64_t v = 0;
     int bits = 0;
     size_t used = 0;
+    uint8_t b = 0;
     while (used < in_size && used < 8)
     {
-        uint8_t b = in_data[used++];
+        b = in_data[used++];
         v += (uint64_t)(b & 0x7f) << bits;
         if ((b & 0x80) == 0)
         {
@@ -41,8 +52,17 @@ uint64_t unpack_u64_dyn(const uint8_t* in_data, size_t in_size, size_t* out_size
     }
     if (used < in_size)
     {
-        uint8_t b = in_data[used++];
+        b = in_data[used++];
         v += (uint64_t)b << 56;
+    }
+    else if ((b & 0x80) != 0)
+    {
+        errno = EINVAL;
+        if (out_size)
+        {
+            *out_size = 0;
+        }
+        return 0;
     }
   done:
     if (out_size)
@@ -79,12 +99,22 @@ size_t pack_u64_dyn_v2(uint8_t out[9], uint64_t v)
 
 uint64_t unpack_u64_dyn_v2(const uint8_t* in_data, size_t in_size, size_t* out_size)
 {
+    if (in_size == 0)
+    {
+        errno = EINVAL;
+        if (out_size)
+        {
+            *out_size = 0;
+        }
+        return 0;
+    }
     uint64_t v = 0;
     int bits = 0;
     size_t used = 0;
+    uint8_t b = 0;
     while (used < in_size && used < 8)
     {
-        uint8_t b = in_data[used++];
+        b = in_data[used++];
         v += (uint64_t)(b & 0x7f) << bits;
         if ((b & 0x80) == 0)
         {
@@ -95,8 +125,17 @@ uint64_t unpack_u64_dyn_v2(const uint8_t* in_data, size_t in_size, size_t* out_s
     }
     if (used < in_size)
     {
-        uint8_t b = in_data[used++];
+        b = in_data[used++];
         v += (uint64_t)b << 56;
+    }
+    else if ((b & 0x80) != 0)
+    {
+        errno = EINVAL;
+        if (out_size)
+        {
+            *out_size = 0;
+        }
+        return 0;
     }
   done:
     if (out_size)


### PR DESCRIPTION
## Summary
- report `EINVAL` when C decoders encounter incomplete input
- cover insufficient input with unit tests

## Testing
- `gcc -std=c99 -Wall -Wextra test.c u64_dyn.c -o test && ./test && echo "tests passed"`


------
https://chatgpt.com/codex/tasks/task_e_68990d3c178483258849805752d2fd6c