### PR TITLE
Add C++ implementation using templates

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -1,0 +1,17 @@
+name: C++
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build
+        working-directory: cpp
+        run: g++ -std=c++17 test.cpp -o test
+      - name: Run tests
+        working-directory: cpp
+        run: ./test

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ u64_dyn, i64_dyn, u64_dyn_v2, and i64_dyn_v2 are variable-length codings of 64-b
 ## Implementations
 
 - [C](c)
-- C++
+- [C++](cpp/u64_dyn.hpp)
     - [Soup](https://github.com/calamity-inc/Soup) has implementations for [reading](https://github.com/calamity-inc/Soup/blob/senpai/soup/Reader.cpp) and [writing](https://github.com/calamity-inc/Soup/blob/senpai/soup/Writer.cpp)
 - [JavaScript](js)
 - [Lua](lua/u64_dyn.lua)

--- a/cpp/test.cpp
+++ b/cpp/test.cpp
@@ -1,0 +1,117 @@
+#include "u64_dyn.hpp"
+
+#include <cassert>
+#include <cstdint>
+#include <cstring>
+#include <climits>
+#include <stdexcept>
+
+struct UPair { uint64_t v; const char* d; size_t s; };
+struct IPair { int64_t v; const char* d; size_t s; };
+
+#define COUNT(x) (sizeof(x) / sizeof(0[x]))
+
+int main()
+{
+    uint8_t data[9];
+    size_t out_size;
+    {
+        UPair pairs[] = {
+            { 0, "\x00", 1 },
+            { 0x7f, "\x7F", 1 },
+            { 0x80, "\x80\x00", 2 },
+            { 1337, "\xB9\x09", 2 },
+            { 42069, "\xD5\xC7\x01", 3 },
+            { 0xffffffffffffffffULL, "\xFF\xFE\xFE\xFE\xFE\xFE\xFE\xFE\xFE", 9 },
+            { 0x8000000000000000ULL, "\x80\xFF\xFE\xFE\xFE\xFE\xFE\xFE\x7E", 9 },
+        };
+        for (size_t i = 0; i != COUNT(pairs); ++i)
+        {
+            const UPair* pair = &pairs[i];
+            assert(pack_u64_dyn<2>(data, pair->v) == pair->s);
+            assert(std::memcmp(data, pair->d, pair->s) == 0);
+            uint64_t out_v = unpack_u64_dyn<2>(data, pair->s, &out_size);
+            assert(out_v == pair->v);
+        }
+    }
+    {
+        UPair pairs[] = {
+            { 0, "\x00", 1 },
+            { 0x7f, "\x7F", 1 },
+            { 0x80, "\x80\x01", 2 },
+            { 1337, "\xB9\x0A", 2 },
+            { 42069, "\xD5\xC8\x02", 3 },
+            { 0xffffffffffffffffULL, "\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF", 9 },
+            { 0x8000000000000000ULL, "\x80\x80\x80\x80\x80\x80\x80\x80\x80", 9 },
+        };
+        for (size_t i = 0; i != COUNT(pairs); ++i)
+        {
+            const UPair* pair = &pairs[i];
+            assert(pack_u64_dyn<1>(data, pair->v) == pair->s);
+            assert(std::memcmp(data, pair->d, pair->s) == 0);
+            uint64_t out_v = unpack_u64_dyn<1>(data, pair->s, &out_size);
+            assert(out_v == pair->v);
+        }
+    }
+    {
+        IPair pairs[] = {
+            { 0, "\x00", 1 },
+            { 0x7f, "\xBF\x01", 2 },
+            { 0x80, "\x80\x02", 2 },
+            { 1337, "\xB9\x14", 2 },
+            { 42069, "\x95\x91\x05", 3 },
+            { -1, "\x41", 1 },
+            { INT64_MIN, "\x40", 1 },
+        };
+        for (size_t i = 0; i != COUNT(pairs); ++i)
+        {
+            const IPair* pair = &pairs[i];
+            assert(pack_i64_dyn<1>(data, pair->v) == pair->s);
+            assert(std::memcmp(data, pair->d, pair->s) == 0);
+            int64_t out_v = unpack_i64_dyn<1>(data, pair->s, &out_size);
+            assert(out_v == pair->v);
+        }
+    }
+    {
+        IPair pairs[] = {
+            { 0, "\x00", 1 },
+            { 0x7f, "\xBF\x00", 2 },
+            { 0x80, "\x80\x01", 2 },
+            { 1337, "\xB9\x13", 2 },
+            { 42069, "\x95\x90\x04", 3 },
+            { -1, "\x40", 1 },
+            { INT64_MIN, "\xFF\xFE\xFE\xFE\xFE\xFE\xFE\xFE\xFE", 9 },
+        };
+        for (size_t i = 0; i != COUNT(pairs); ++i)
+        {
+            const IPair* pair = &pairs[i];
+            assert(pack_i64_dyn<2>(data, pair->v) == pair->s);
+            assert(std::memcmp(data, pair->d, pair->s) == 0);
+            int64_t out_v = unpack_i64_dyn<2>(data, pair->s, &out_size);
+            assert(out_v == pair->v);
+        }
+    }
+    {
+        const uint8_t bad1[] = { 0x80 };
+        const uint8_t bad2[] = { 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80 };
+        struct { const uint8_t* d; size_t s; } bads[] = {
+            { nullptr, 0 },
+            { bad1, sizeof(bad1) },
+            { bad2, sizeof(bad2) },
+        };
+        for (size_t i = 0; i != COUNT(bads); ++i)
+        {
+            size_t used;
+            bool threw;
+            try { (void)unpack_u64_dyn<1>(bads[i].d, bads[i].s, &used); threw = false; } catch (const std::exception&) { threw = true; }
+            assert(threw);
+            try { (void)unpack_i64_dyn<1>(bads[i].d, bads[i].s, &used); threw = false; } catch (const std::exception&) { threw = true; }
+            assert(threw);
+            try { (void)unpack_i64_dyn<2>(bads[i].d, bads[i].s, &used); threw = false; } catch (const std::exception&) { threw = true; }
+            assert(threw);
+            try { (void)unpack_u64_dyn<2>(bads[i].d, bads[i].s, &used); threw = false; } catch (const std::exception&) { threw = true; }
+            assert(threw);
+        }
+    }
+    return 0;
+}

--- a/cpp/u64_dyn.hpp
+++ b/cpp/u64_dyn.hpp
@@ -1,0 +1,137 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+
+template <int Version>
+inline size_t pack_u64_dyn(uint8_t out[9], uint64_t v)
+{
+    static_assert(Version == 1 || Version == 2, "Version must be 1 or 2");
+    size_t i = 0;
+    while (i != 8)
+    {
+        const uint8_t cur = v & 0x7f;
+        v >>= 7;
+        if (v != 0)
+        {
+            out[i++] = cur | 0x80;
+            if constexpr (Version == 2)
+            {
+                v -= 1;
+            }
+        }
+        else
+        {
+            out[i++] = cur;
+            return i;
+        }
+    }
+    if (v != 0)
+    {
+        out[i++] = static_cast<uint8_t>(v);
+    }
+    return i;
+}
+
+template <int Version>
+inline uint64_t unpack_u64_dyn(const uint8_t* in_data, size_t in_size, size_t* out_size)
+{
+    static_assert(Version == 1 || Version == 2, "Version must be 1 or 2");
+    if (!in_data)
+    {
+        throw std::runtime_error("malformed dynamic integer");
+    }
+    uint64_t v = 0;
+    int bits = 0;
+    size_t used = 0;
+    while (true)
+    {
+        if (used >= in_size)
+        {
+            throw std::runtime_error("malformed dynamic integer");
+        }
+        uint8_t b = in_data[used++];
+        if (used == 9)
+        {
+            v += static_cast<uint64_t>(b) << bits;
+            break;
+        }
+        v += static_cast<uint64_t>(b & 0x7f) << bits;
+        if ((b & 0x80) == 0)
+        {
+            break;
+        }
+        bits += 7;
+        if constexpr (Version == 2)
+        {
+            v += static_cast<uint64_t>(1) << bits;
+        }
+    }
+    if (out_size)
+    {
+        *out_size = used;
+    }
+    return v;
+}
+
+template <int Version>
+inline size_t pack_i64_dyn(uint8_t out[9], int64_t v)
+{
+    static_assert(Version == 1 || Version == 2, "Version must be 1 or 2");
+    uint64_t u = static_cast<uint64_t>(v);
+    const uint64_t neg = static_cast<uint64_t>(v < 0);
+    if constexpr (Version == 2)
+    {
+        if (neg)
+        {
+            u = ~u;
+        }
+    }
+    else
+    {
+        if (neg)
+        {
+            u = (~u + 1) & ~(static_cast<uint64_t>(1) << 63);
+        }
+    }
+    return pack_u64_dyn<Version>(out, (neg << 6) | ((u & ~0x3fULL) << 1) | (u & 0x3fULL));
+}
+
+template <int Version>
+inline int64_t unpack_i64_dyn(const uint8_t* in_data, size_t in_size, size_t* out_size)
+{
+    static_assert(Version == 1 || Version == 2, "Version must be 1 or 2");
+    uint64_t u = unpack_u64_dyn<Version>(in_data, in_size, out_size);
+    const uint64_t neg = (u >> 6) & 1;
+    u = ((u >> 1) & ~0x3fULL) | (u & 0x3fULL);
+    int64_t v;
+    if constexpr (Version == 2)
+    {
+        v = static_cast<int64_t>(u);
+        if (neg)
+        {
+            v = ~v;
+        }
+    }
+    else
+    {
+        if (neg)
+        {
+            if (u == 0)
+            {
+                v = static_cast<int64_t>(1) << 63;
+            }
+            else
+            {
+                v = -static_cast<int64_t>(u);
+            }
+        }
+        else
+        {
+            v = static_cast<int64_t>(u);
+        }
+    }
+    return v;
+}
+


### PR DESCRIPTION
## Summary
- implement header-only C++ versions of u64/i64 dynamic encoders with a template parameter for v1 or v2
- return decoded value from C++ unpack helpers and raise `std::runtime_error` on malformed data
- add C++ tests covering signed/unsigned encodings and exception handling
- mention the new C++ header in the README
- add GitHub workflow to build and run the C++ tests

## Testing
- `g++ -std=c++17 cpp/test.cpp -o cpp/test && ./cpp/test`
- `gcc -std=c99 c/test.c c/u64_dyn.c -o c/test && ./c/test`


------
https://chatgpt.com/codex/tasks/task_e_6899513e74608325a512230d766ae93b