### PR TITLE
Add composer.json for PHP library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "calamity-inc/u64-dyn",
+    "description": "Variable-length 64-bit integer codings that take at most 9 bytes.",
+    "type": "library",
+    "license": "Unlicense",
+    "require": {
+        "php": ">=7.0"
+    },
+    "autoload": {
+        "files": ["php/u64_dyn.php"]
+    },
+    "scripts": {
+        "test": "php php/test.php"
+    }
+}


### PR DESCRIPTION
## Summary
- add composer configuration with library metadata, PHP ≥7 requirement, file-based autoloading, and test script

## Testing
- `composer validate`
- `php php/test.php`


------
https://chatgpt.com/codex/tasks/task_e_68995d20f2b48325aacb210253e3905b