### PR TITLE
Limit push workflow runs to senpai branch

### DIFF
--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -2,6 +2,8 @@ name: C
 
 on:
   push:
+    branches:
+      - senpai
   pull_request:
 
 jobs:

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -2,6 +2,8 @@ name: C++
 
 on:
   push:
+    branches:
+      - senpai
   pull_request:
 
 jobs:

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -2,6 +2,8 @@ name: JavaScript
 
 on:
   push:
+    branches:
+      - senpai
   pull_request:
 
 jobs:

--- a/.github/workflows/lua.yml
+++ b/.github/workflows/lua.yml
@@ -2,6 +2,8 @@ name: Lua
 
 on:
   push:
+    branches:
+      - senpai
   pull_request:
 
 jobs:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -2,6 +2,8 @@ name: PHP
 
 on:
   push:
+    branches:
+      - senpai
   pull_request:
 
 jobs:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -2,6 +2,8 @@ name: Python
 
 on:
   push:
+    branches:
+      - senpai
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Summary
- restrict push-triggered workflows to the `senpai` branch
- allow pull request workflows from any branch

## Testing
- `cd c && gcc test.c u64_dyn.c -o test && ./test && echo 'C tests passed'`
- `cd cpp && g++ -std=c++17 test.cpp -o test && ./test && echo 'C++ tests passed'`
- `cd js && npm test && echo 'JS tests passed'`
- `apt-get update`
- `apt-get install -y lua5.4`
- `cd lua && lua test.lua && echo 'Lua tests passed'`
- `cd php && php test.php && echo 'PHP tests passed'`
- `cd python && python test.py && echo 'Python tests passed'`


------
https://chatgpt.com/codex/tasks/task_e_689957a6fcf08325892d7d5acf0a1452