### PR TITLE
Add Go port

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run tests
         working-directory: go
-        run: go test ./...
+        run: go test

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,16 @@
+name: Go
+
+on:
+  push:
+    branches:
+      - senpai
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests
+        working-directory: go
+        run: go test ./...

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ u64_dyn, i64_dyn, u64_dyn_v2, and i64_dyn_v2 are variable-length codings of 64-b
 - [C](c)
 - [C++](cpp/u64_dyn.hpp)
     - [Soup](https://github.com/calamity-inc/Soup) has implementations for [reading](https://github.com/calamity-inc/Soup/blob/senpai/soup/Reader.cpp) and [writing](https://github.com/calamity-inc/Soup/blob/senpai/soup/Writer.cpp)
+- [Go](go)
 - [JavaScript](js)
 - [Lua](lua/u64_dyn.lua)
     - The [APM](https://github.com/PlutoLang/apm#readme) package for this can be found [here](https://gist.github.com/Sainan/02c3ac9cea5015341412c92feec95e56)

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,4 @@
+module u64dyn
+
+go 1.20
+

--- a/go/u64_dyn.go
+++ b/go/u64_dyn.go
@@ -1,0 +1,165 @@
+package u64dyn
+
+import "errors"
+
+// PackU64Dyn packs an integer into u64_dyn bytes.
+func PackU64Dyn(v uint64) []byte {
+	out := make([]byte, 0, 9)
+	for i := 0; i < 8; i++ {
+		cur := byte(v & 0x7f)
+		v >>= 7
+		if v != 0 {
+			out = append(out, cur|0x80)
+		} else {
+			out = append(out, cur)
+			return out
+		}
+	}
+	if v != 0 {
+		out = append(out, byte(v))
+	}
+	return out
+}
+
+// UnpackU64Dyn unpacks a u64_dyn encoded integer from buf starting at offset.
+// It returns the value, the new offset, or an error if there is insufficient data.
+func UnpackU64Dyn(buf []byte, offset int) (uint64, int, error) {
+	var v uint64
+	bits := uint(0)
+	used := 0
+	for used < 8 {
+		if offset+used >= len(buf) {
+			return 0, offset, errors.New("insufficient data")
+		}
+		b := uint64(buf[offset+used])
+		v += (b & 0x7f) << bits
+		used++
+		if (b & 0x80) == 0 {
+			return v, offset + used, nil
+		}
+		bits += 7
+	}
+	if offset+used >= len(buf) {
+		return 0, offset, errors.New("insufficient data")
+	}
+	b := uint64(buf[offset+used])
+	v += b << 56
+	used++
+	return v, offset + used, nil
+}
+
+// PackU64DynV2 packs an integer using u64_dyn_v2.
+func PackU64DynV2(v uint64) []byte {
+	out := make([]byte, 0, 9)
+	for i := 0; i < 8; i++ {
+		cur := byte(v & 0x7f)
+		v >>= 7
+		if v != 0 {
+			out = append(out, cur|0x80)
+			v--
+		} else {
+			out = append(out, cur)
+			return out
+		}
+	}
+	if v != 0 {
+		out = append(out, byte(v))
+	}
+	return out
+}
+
+// UnpackU64DynV2 unpacks a u64_dyn_v2 encoded integer from buf starting at offset.
+// It returns the value, the new offset, or an error if there is insufficient data.
+func UnpackU64DynV2(buf []byte, offset int) (uint64, int, error) {
+	var v uint64
+	bits := uint(0)
+	used := 0
+	for used < 8 {
+		if offset+used >= len(buf) {
+			return 0, offset, errors.New("insufficient data")
+		}
+		b := uint64(buf[offset+used])
+		v += (b & 0x7f) << bits
+		used++
+		if (b & 0x80) == 0 {
+			return v, offset + used, nil
+		}
+		bits += 7
+		v += 1 << bits
+	}
+	if offset+used >= len(buf) {
+		return 0, offset, errors.New("insufficient data")
+	}
+	b := uint64(buf[offset+used])
+	v += b << 56
+	used++
+	return v, offset + used, nil
+}
+
+// PackI64Dyn packs a signed integer using i64_dyn.
+func PackI64Dyn(v int64) []byte {
+	var u uint64
+	var neg uint64
+	if v < 0 {
+		neg = 1
+		u = uint64(-v) & ((1 << 63) - 1)
+	} else {
+		u = uint64(v)
+	}
+	packed := (neg << 6) | ((u & ^uint64(0x3f)) << 1) | (u & 0x3f)
+	return PackU64Dyn(packed)
+}
+
+// UnpackI64Dyn unpacks an i64_dyn encoded integer from buf starting at offset.
+// It returns the value, the new offset, or an error if there is insufficient data.
+func UnpackI64Dyn(buf []byte, offset int) (int64, int, error) {
+	u64, idx, err := UnpackU64Dyn(buf, offset)
+	if err != nil {
+		return 0, offset, err
+	}
+	neg := (u64 >> 6) & 1
+	u := ((u64 >> 1) & ^uint64(0x3f)) | (u64 & 0x3f)
+	var v int64
+	if neg != 0 {
+		if u == 0 {
+			v = -1 << 63
+		} else {
+			v = -int64(u)
+		}
+	} else {
+		v = int64(u)
+	}
+	return v, idx, nil
+}
+
+// PackI64DynV2 packs a signed integer using i64_dyn_v2.
+func PackI64DynV2(v int64) []byte {
+	var u uint64
+	var neg uint64
+	if v < 0 {
+		neg = 1
+		u = uint64(-v) - 1
+	} else {
+		u = uint64(v)
+	}
+	packed := (neg << 6) | ((u & ^uint64(0x3f)) << 1) | (u & 0x3f)
+	return PackU64DynV2(packed)
+}
+
+// UnpackI64DynV2 unpacks an i64_dyn_v2 encoded integer from buf starting at offset.
+// It returns the value, the new offset, or an error if there is insufficient data.
+func UnpackI64DynV2(buf []byte, offset int) (int64, int, error) {
+	u64, idx, err := UnpackU64DynV2(buf, offset)
+	if err != nil {
+		return 0, offset, err
+	}
+	neg := (u64 >> 6) & 1
+	u := ((u64 >> 1) & ^uint64(0x3f)) | (u64 & 0x3f)
+	var v int64
+	if neg != 0 {
+		v = -int64(u) - 1
+	} else {
+		v = int64(u)
+	}
+	return v, idx, nil
+}

--- a/go/u64_dyn_test.go
+++ b/go/u64_dyn_test.go
@@ -1,0 +1,137 @@
+package u64dyn
+
+import "testing"
+
+func TestPackUnpackU64(t *testing.T) {
+	cases := map[uint64][]byte{
+		0:                  {0x00},
+		0x7F:               {0x7F},
+		0x80:               {0x80, 0x01},
+		1337:               {0xB9, 0x0A},
+		42069:              {0xD5, 0xC8, 0x02},
+		0xFFFFFFFFFFFFFFFF: {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF},
+		0x8000000000000000: {0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80},
+	}
+	for val, enc := range cases {
+		got := PackU64Dyn(val)
+		if !equalSlices(got, enc) {
+			t.Errorf("PackU64Dyn(%d) = %v, want %v", val, got, enc)
+		}
+		v, off, err := UnpackU64Dyn(enc, 0)
+		if err != nil {
+			t.Fatalf("UnpackU64Dyn returned error: %v", err)
+		}
+		if v != val || off != len(enc) {
+			t.Errorf("UnpackU64Dyn(%v) = (%d,%d), want (%d,%d)", enc, v, off, val, len(enc))
+		}
+	}
+}
+
+func TestPackUnpackI64(t *testing.T) {
+	cases := map[int64][]byte{
+		0:                   {0x00},
+		0x7F:                {0xBF, 0x01},
+		0x80:                {0x80, 0x02},
+		1337:                {0xB9, 0x14},
+		42069:               {0x95, 0x91, 0x05},
+		-1:                  {0x41},
+		-0x8000000000000000: {0x40},
+	}
+	for val, enc := range cases {
+		got := PackI64Dyn(val)
+		if !equalSlices(got, enc) {
+			t.Errorf("PackI64Dyn(%d) = %v, want %v", val, got, enc)
+		}
+		v, off, err := UnpackI64Dyn(enc, 0)
+		if err != nil {
+			t.Fatalf("UnpackI64Dyn returned error: %v", err)
+		}
+		if v != val || off != len(enc) {
+			t.Errorf("UnpackI64Dyn(%v) = (%d,%d), want (%d,%d)", enc, v, off, val, len(enc))
+		}
+	}
+}
+
+func TestPackUnpackU64V2(t *testing.T) {
+	cases := map[uint64][]byte{
+		0:                  {0x00},
+		0x7F:               {0x7F},
+		0x80:               {0x80, 0x00},
+		1337:               {0xB9, 0x09},
+		42069:              {0xD5, 0xC7, 0x01},
+		0xFFFFFFFFFFFFFFFF: {0xFF, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE},
+		0x8000000000000000: {0x80, 0xFF, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0x7E},
+	}
+	for val, enc := range cases {
+		got := PackU64DynV2(val)
+		if !equalSlices(got, enc) {
+			t.Errorf("PackU64DynV2(%d) = %v, want %v", val, got, enc)
+		}
+		v, off, err := UnpackU64DynV2(enc, 0)
+		if err != nil {
+			t.Fatalf("UnpackU64DynV2 returned error: %v", err)
+		}
+		if v != val || off != len(enc) {
+			t.Errorf("UnpackU64DynV2(%v) = (%d,%d), want (%d,%d)", enc, v, off, val, len(enc))
+		}
+	}
+}
+
+func TestPackUnpackI64V2(t *testing.T) {
+	cases := map[int64][]byte{
+		0:                   {0x00},
+		0x7F:                {0xBF, 0x00},
+		0x80:                {0x80, 0x01},
+		1337:                {0xB9, 0x13},
+		42069:               {0x95, 0x90, 0x04},
+		-1:                  {0x40},
+		-0x8000000000000000: {0xFF, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE},
+	}
+	for val, enc := range cases {
+		got := PackI64DynV2(val)
+		if !equalSlices(got, enc) {
+			t.Errorf("PackI64DynV2(%d) = %v, want %v", val, got, enc)
+		}
+		v, off, err := UnpackI64DynV2(enc, 0)
+		if err != nil {
+			t.Fatalf("UnpackI64DynV2 returned error: %v", err)
+		}
+		if v != val || off != len(enc) {
+			t.Errorf("UnpackI64DynV2(%v) = (%d,%d), want (%d,%d)", enc, v, off, val, len(enc))
+		}
+	}
+}
+
+func TestTruncated(t *testing.T) {
+	truncated := [][]byte{
+		{},
+		{0x80},
+		{0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80},
+	}
+	for _, enc := range truncated {
+		if _, _, err := UnpackU64Dyn(enc, 0); err == nil {
+			t.Errorf("UnpackU64Dyn should fail for %v", enc)
+		}
+		if _, _, err := UnpackI64Dyn(enc, 0); err == nil {
+			t.Errorf("UnpackI64Dyn should fail for %v", enc)
+		}
+		if _, _, err := UnpackU64DynV2(enc, 0); err == nil {
+			t.Errorf("UnpackU64DynV2 should fail for %v", enc)
+		}
+		if _, _, err := UnpackI64DynV2(enc, 0); err == nil {
+			t.Errorf("UnpackI64DynV2 should fail for %v", enc)
+		}
+	}
+}
+
+func equalSlices(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/go/u64_dyn_test.go
+++ b/go/u64_dyn_test.go
@@ -1,6 +1,9 @@
 package u64dyn
 
-import "testing"
+import (
+	"bytes"
+	"testing"
+)
 
 func TestPackUnpackU64(t *testing.T) {
 	cases := map[uint64][]byte{
@@ -14,7 +17,7 @@ func TestPackUnpackU64(t *testing.T) {
 	}
 	for val, enc := range cases {
 		got := PackU64Dyn(val)
-		if !equalSlices(got, enc) {
+		if !bytes.Equal(got, enc) {
 			t.Errorf("PackU64Dyn(%d) = %v, want %v", val, got, enc)
 		}
 		v, off, err := UnpackU64Dyn(enc, 0)
@@ -39,7 +42,7 @@ func TestPackUnpackI64(t *testing.T) {
 	}
 	for val, enc := range cases {
 		got := PackI64Dyn(val)
-		if !equalSlices(got, enc) {
+		if !bytes.Equal(got, enc) {
 			t.Errorf("PackI64Dyn(%d) = %v, want %v", val, got, enc)
 		}
 		v, off, err := UnpackI64Dyn(enc, 0)
@@ -64,7 +67,7 @@ func TestPackUnpackU64V2(t *testing.T) {
 	}
 	for val, enc := range cases {
 		got := PackU64DynV2(val)
-		if !equalSlices(got, enc) {
+		if !bytes.Equal(got, enc) {
 			t.Errorf("PackU64DynV2(%d) = %v, want %v", val, got, enc)
 		}
 		v, off, err := UnpackU64DynV2(enc, 0)
@@ -89,7 +92,7 @@ func TestPackUnpackI64V2(t *testing.T) {
 	}
 	for val, enc := range cases {
 		got := PackI64DynV2(val)
-		if !equalSlices(got, enc) {
+		if !bytes.Equal(got, enc) {
 			t.Errorf("PackI64DynV2(%d) = %v, want %v", val, got, enc)
 		}
 		v, off, err := UnpackI64DynV2(enc, 0)
@@ -122,16 +125,4 @@ func TestTruncated(t *testing.T) {
 			t.Errorf("UnpackI64DynV2 should fail for %v", enc)
 		}
 	}
-}
-
-func equalSlices(a, b []byte) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
 }


### PR DESCRIPTION
## Summary
- implement u64_dyn, u64_dyn_v2, i64_dyn and i64_dyn_v2 in Go
- add tests for encoding/decoding and truncated buffers
- document Go implementation in README
- add GitHub workflow running Go tests

## Testing
- `cd go && go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689970ed946483259ce0dc6633fc98ee