### PR TITLE
Wrap JS u64 helpers to 64 bits

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "u64-dyn",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Variable-length 64-bit integer codings that take at most 9 bytes.",
   "repository": {
     "type": "git",

--- a/js/test.js
+++ b/js/test.js
@@ -58,6 +58,13 @@ for (const [val, enc] of casesU64v2) {
   assert.deepStrictEqual([value, off], [val, enc.length], `unpack_u64_dyn_v2 mismatch for ${val}`);
 }
 
+// Ensure unpack handles contrived overflow by wrapping to 64 bits
+{
+  const enc = Uint8Array.from([0xff, 0xff, 0xfe, 0xfe, 0xfe, 0xfe, 0xfe, 0xfe, 0xfe]);
+  const [value, off] = unpack_u64_dyn_v2(enc);
+  assert.deepStrictEqual([value, off], [0x7fn, 9], 'unpack_u64_dyn_v2 should wrap modulo 2^64');
+}
+
 const casesI64v2 = new Map([
   [0n, [0x00]],
   [0x7fn, [0xbf, 0x00]],

--- a/js/test.js
+++ b/js/test.js
@@ -58,13 +58,6 @@ for (const [val, enc] of casesU64v2) {
   assert.deepStrictEqual([value, off], [val, enc.length], `unpack_u64_dyn_v2 mismatch for ${val}`);
 }
 
-// Ensure unpack handles contrived overflow by wrapping to 64 bits
-{
-  const enc = Uint8Array.from([0xff, 0xff, 0xfe, 0xfe, 0xfe, 0xfe, 0xfe, 0xfe, 0xfe]);
-  assert.deepStrictEqual(unpack_u64_dyn_v2(enc), [0x7fn, 9], 'unpack_u64_dyn_v2 should wrap modulo 2^64');
-  assert.deepStrictEqual(unpack_i64_dyn_v2(enc), [-64n, 9], 'unpack_i64_dyn_v2 should wrap modulo 2^64');
-}
-
 const casesI64v2 = new Map([
   [0n, [0x00]],
   [0x7fn, [0xbf, 0x00]],
@@ -103,4 +96,11 @@ for (const enc of truncatedCases) {
   expectThrow(() => unpack_i64_dyn(buf), 'unpack_i64_dyn should throw on insufficient data');
   expectThrow(() => unpack_i64_dyn_v2(buf), 'unpack_i64_dyn_v2 should throw on insufficient data');
   expectThrow(() => unpack_u64_dyn_v2(buf), 'unpack_u64_dyn_v2 should throw on insufficient data');
+}
+
+// Since JS needs bigint for 64-bit integers, we also need to be sure it unpack is modulo 2^64 for contrived inputs
+{
+  const enc = Uint8Array.from([0xff, 0xff, 0xfe, 0xfe, 0xfe, 0xfe, 0xfe, 0xfe, 0xfe]);
+  assert.deepStrictEqual(unpack_u64_dyn_v2(enc), [0x7fn, 9], 'unpack_u64_dyn_v2 should wrap modulo 2^64');
+  assert.deepStrictEqual(unpack_i64_dyn_v2(enc), [-64n, 9], 'unpack_i64_dyn_v2 should wrap modulo 2^64');
 }

--- a/js/test.js
+++ b/js/test.js
@@ -61,8 +61,8 @@ for (const [val, enc] of casesU64v2) {
 // Ensure unpack handles contrived overflow by wrapping to 64 bits
 {
   const enc = Uint8Array.from([0xff, 0xff, 0xfe, 0xfe, 0xfe, 0xfe, 0xfe, 0xfe, 0xfe]);
-  const [value, off] = unpack_u64_dyn_v2(enc);
-  assert.deepStrictEqual([value, off], [0x7fn, 9], 'unpack_u64_dyn_v2 should wrap modulo 2^64');
+  assert.deepStrictEqual(unpack_u64_dyn_v2(enc), [0x7fn, 9], 'unpack_u64_dyn_v2 should wrap modulo 2^64');
+  assert.deepStrictEqual(unpack_i64_dyn_v2(enc), [-64n, 9], 'unpack_i64_dyn_v2 should wrap modulo 2^64');
 }
 
 const casesI64v2 = new Map([

--- a/js/u64_dyn.js
+++ b/js/u64_dyn.js
@@ -2,6 +2,7 @@
 
 function pack_u64_dyn(v) {
   if (typeof v !== 'bigint') v = BigInt(v);
+  v = BigInt.asUintN(64, v);
   const out = [];
   for (let i = 0; i < 8; i++) {
     const cur = v & 0x7fn;
@@ -28,18 +29,19 @@ function unpack_u64_dyn(buf, offset = 0) {
     const b = BigInt(buf[offset + used]);
     v += (b & 0x7fn) << bits;
     if ((b & 0x80n) === 0n) {
-      return [v, offset + used + 1];
+      return [BigInt.asUintN(64, v), offset + used + 1];
     }
     bits += 7n;
   }
   if (offset + used >= buf.length) throw new RangeError('Insufficient data');
   const b = BigInt(buf[offset + used]);
   v += b << 56n;
-  return [v, offset + used + 1];
+  return [BigInt.asUintN(64, v), offset + used + 1];
 }
 
 function pack_u64_dyn_v2(v) {
   if (typeof v !== 'bigint') v = BigInt(v);
+  v = BigInt.asUintN(64, v);
   const out = [];
   for (let i = 0; i < 8; i++) {
     const cur = v & 0x7fn;
@@ -67,7 +69,7 @@ function unpack_u64_dyn_v2(buf, offset = 0) {
     const b = BigInt(buf[offset + used]);
     v += (b & 0x7fn) << bits;
     if ((b & 0x80n) === 0n) {
-      return [v, offset + used + 1];
+      return [BigInt.asUintN(64, v), offset + used + 1];
     }
     bits += 7n;
     v += 1n << bits;
@@ -75,7 +77,7 @@ function unpack_u64_dyn_v2(buf, offset = 0) {
   if (offset + used >= buf.length) throw new RangeError('Insufficient data');
   const b = BigInt(buf[offset + used]);
   v += b << 56n;
-  return [v, offset + used + 1];
+  return [BigInt.asUintN(64, v), offset + used + 1];
 }
 
 function pack_i64_dyn(v) {


### PR DESCRIPTION
## Summary
- ensure JavaScript pack/unpack functions mask values to uint64
- add test for overflowed nine-byte input

## Testing
- `cd js && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a02a7c0608325957ddc97c3abe763