### PR TITLE
Branchless approach to i64_dyn negative value decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The i64 value is split into (neg, u63) like so:
 ```
 neg := i64 < 0
 if neg:
-    u63 := (i64 * -1) & ~(1 << 63)
+    u63 := (~i64 + 1) & ~(1 << 63)
 else:
     u63 := i64
 ```
@@ -39,7 +39,10 @@ This is rejoined into a u64 with neg in bit 6:
 ```
 u64 := (neg << 6) | ((u63 & ~0x3f) << 1) | (u63 & 0x3f)
 ```
-This value is then encoded using u64_dyn. Decoding is complicated slightly by the fact that `I64_MIN` is encoded as effectively `-0`.
+This value is then encoded using u64_dyn. When decoding, if `neg` is set the original value is recovered with:
+```
+i64 := ~(u63 - 1) | (1 << 63)
+```
 
 ### i64_dyn_v2
 

--- a/c/u64_dyn.c
+++ b/c/u64_dyn.c
@@ -139,11 +139,10 @@ bool unpack_i64_dyn(const uint8_t* in_data, size_t in_size, int64_t* out_v, size
         return false;
     }
     const bool neg = (u >> 6) & 1;
-    u = ((u >> 1) & ~((uint64_t)0x3f)) | (u & 0x3f);
-    int64_t v = (int64_t)u;
+    int64_t v = ((u >> 1) & ~((uint64_t)0x3f)) | (u & 0x3f);
     if (neg)
     {
-        v = (int64_t)(~(u - 1) | ((uint64_t)1 << 63));
+        v = (int64_t)(~(v - 1) | ((uint64_t)1 << 63));
     }
     if (out_v)
     {

--- a/c/u64_dyn.c
+++ b/c/u64_dyn.c
@@ -140,21 +140,10 @@ bool unpack_i64_dyn(const uint8_t* in_data, size_t in_size, int64_t* out_v, size
     }
     const bool neg = (u >> 6) & 1;
     u = ((u >> 1) & ~((uint64_t)0x3f)) | (u & 0x3f);
-    int64_t v;
+    int64_t v = (int64_t)u;
     if (neg)
     {
-        if (u == 0)
-        {
-            v = (int64_t)1 << 63;
-        }
-        else
-        {
-            v = -(int64_t)u;
-        }
-    }
-    else
-    {
-        v = (int64_t)u;
+        v = (int64_t)(~(u - 1) | ((uint64_t)1 << 63));
     }
     if (out_v)
     {

--- a/cpp/u64_dyn.hpp
+++ b/cpp/u64_dyn.hpp
@@ -104,11 +104,9 @@ inline int64_t unpack_i64_dyn(const uint8_t* in_data, size_t in_size, size_t* ou
     static_assert(Version == 1 || Version == 2, "Version must be 1 or 2");
     uint64_t u = unpack_u64_dyn<Version>(in_data, in_size, out_size);
     const uint64_t neg = (u >> 6) & 1;
-    u = ((u >> 1) & ~0x3fULL) | (u & 0x3fULL);
-    int64_t v;
+    int64_t v = ((u >> 1) & ~0x3fULL) | (u & 0x3fULL);
     if constexpr (Version == 2)
     {
-        v = static_cast<int64_t>(u);
         if (neg)
         {
             v = ~v;
@@ -116,10 +114,9 @@ inline int64_t unpack_i64_dyn(const uint8_t* in_data, size_t in_size, size_t* ou
     }
     else
     {
-        v = static_cast<int64_t>(u);
         if (neg)
         {
-            v = static_cast<int64_t>(~(u - 1) | (static_cast<uint64_t>(1) << 63));
+            v = static_cast<int64_t>(~(v - 1) | (static_cast<uint64_t>(1) << 63));
         }
     }
     return v;

--- a/cpp/u64_dyn.hpp
+++ b/cpp/u64_dyn.hpp
@@ -116,20 +116,10 @@ inline int64_t unpack_i64_dyn(const uint8_t* in_data, size_t in_size, size_t* ou
     }
     else
     {
+        v = static_cast<int64_t>(u);
         if (neg)
         {
-            if (u == 0)
-            {
-                v = static_cast<int64_t>(1) << 63;
-            }
-            else
-            {
-                v = -static_cast<int64_t>(u);
-            }
-        }
-        else
-        {
-            v = static_cast<int64_t>(u);
+            v = static_cast<int64_t>(~(u - 1) | (static_cast<uint64_t>(1) << 63));
         }
     }
     return v;

--- a/go/u64_dyn.go
+++ b/go/u64_dyn.go
@@ -98,13 +98,11 @@ func UnpackU64DynV2(buf []byte, offset int) (uint64, int, error) {
 
 // PackI64Dyn packs a signed integer using i64_dyn.
 func PackI64Dyn(v int64) []byte {
-    var u uint64
-    var neg uint64
+    var u uint64 = uint64(v)
+    neg := uint64(0)
     if v < 0 {
         neg = 1
-        u = uint64(-v) & ((1 << 63) - 1)
-    } else {
-        u = uint64(v)
+        u = (^u + 1) & ^(uint64(1) << 63)
     }
     packed := (neg << 6) | ((u & ^uint64(0x3f)) << 1) | (u & 0x3f)
     return PackU64Dyn(packed)
@@ -119,15 +117,9 @@ func UnpackI64Dyn(buf []byte, offset int) (int64, int, error) {
     }
     neg := (u64 >> 6) & 1
     u := ((u64 >> 1) & ^uint64(0x3f)) | (u64 & 0x3f)
-    var v int64
+    var v int64 = int64(u)
     if neg != 0 {
-        if u == 0 {
-            v = -1 << 63
-        } else {
-            v = -int64(u)
-        }
-    } else {
-        v = int64(u)
+        v = int64((^(u - 1)) | (uint64(1) << 63))
     }
     return v, idx, nil
 }

--- a/js/u64_dyn.js
+++ b/js/u64_dyn.js
@@ -83,11 +83,9 @@ function unpack_u64_dyn_v2(buf, offset = 0) {
 function pack_i64_dyn(v) {
   if (typeof v !== 'bigint') v = BigInt(v);
   const neg = v < 0n ? 1n : 0n;
-  let u;
+  let u = v;
   if (neg) {
-    u = (-v) & ((1n << 63n) - 1n);
-  } else {
-    u = v;
+    u = (~v + 1n) & ~(1n << 63n);
   }
   const packed = (neg << 6n) | ((u & ~0x3fn) << 1n) | (u & 0x3fn);
   return pack_u64_dyn(packed);
@@ -98,15 +96,10 @@ function unpack_i64_dyn(buf, offset = 0) {
   let u = u64;
   const neg = (u >> 6n) & 1n;
   u = ((u >> 1n) & ~0x3fn) | (u & 0x3fn);
-  let v;
+  let v = u;
   if (neg) {
-    if (u === 0n) {
-      v = -(1n << 63n);
-    } else {
-      v = -u;
-    }
-  } else {
-    v = u;
+    v = (~(u - 1n)) | (1n << 63n);
+    v = BigInt.asIntN(64, v);
   }
   return [v, idx];
 }

--- a/lua/u64_dyn.lua
+++ b/lua/u64_dyn.lua
@@ -36,7 +36,7 @@ end
 function pack_i64_dyn(v)
     local neg = (v >> 63)
     if v < 0 then
-        v = (v * -1) & ~(1 << 63)
+        v = (~v + 1) & ~(1 << 63)
     end
     return pack_u64_dyn((neg << 6) | ((v & ~0x3f) << 1) | (v & 0x3f))
 end
@@ -47,11 +47,7 @@ function unpack_i64_dyn(str, i)
     local neg = ((v >> 6) & 1) ~= 0
     v = ((v >> 1) & ~0x3f) | (v & 0x3f)
     if neg then
-        if v == 0 then
-            v = 1 << 63
-        else
-            v = v * -1
-        end
+        v = ~(v - 1) | (1 << 63)
     end
     return v, i
 end

--- a/php/u64_dyn.php
+++ b/php/u64_dyn.php
@@ -136,8 +136,7 @@ function pack_i64_dyn($v)
     $neg = ($v >> 63) & 1;
     if ($v < 0)
     {
-        $u = add64(~$v, 1);
-        $u &= ~(-1 << 63);
+        $u = add64(~$v, 1) & ~(-1 << 63);
     }
     else
     {
@@ -155,14 +154,7 @@ function unpack_i64_dyn($str, &$offset = 0)
     $v = $upper | ($v & 0x3f);
     if ($neg)
     {
-        if ($v == 0)
-        {
-            $v = PHP_INT_MIN;
-        }
-        else
-        {
-            $v = -$v;
-        }
+        $v = (~($v - 1)) | (1 << 63);
     }
     return $v;
 }

--- a/python/u64_dyn.py
+++ b/python/u64_dyn.py
@@ -114,7 +114,7 @@ def pack_i64_dyn(v: int) -> bytes:
     """Pack a signed integer using i64_dyn."""
     if v < 0:
         neg = 1
-        u = (-v) & ((1 << 63) - 1)
+        u = (~v + 1) & ((1 << 63) - 1)
     else:
         neg = 0
         u = v
@@ -127,10 +127,9 @@ def unpack_i64_dyn(buf: bytes, offset: int = 0) -> Tuple[int, int]:
     neg = (u64 >> 6) & 1
     u = ((u64 >> 1) & ~0x3F) | (u64 & 0x3F)
     if neg:
-        if u == 0:
-            v = -(1 << 63)
-        else:
-            v = -u
+        v = (~(u - 1) | (1 << 63)) & ((1 << 64) - 1)
+        if v & (1 << 63):
+            v -= 1 << 64
     else:
         v = u
     return v, idx

--- a/python/u64_dyn.py
+++ b/python/u64_dyn.py
@@ -127,9 +127,7 @@ def unpack_i64_dyn(buf: bytes, offset: int = 0) -> Tuple[int, int]:
     neg = (u64 >> 6) & 1
     u = ((u64 >> 1) & ~0x3F) | (u64 & 0x3F)
     if neg:
-        v = (~(u - 1) | (1 << 63)) & ((1 << 64) - 1)
-        if v & (1 << 63):
-            v -= 1 << 64
+        v = ~(u - 1) | -9223372036854775808
     else:
         v = u
     return v, idx

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -96,15 +96,10 @@ pub fn unpack_i64_dyn(data: &[u8]) -> Option<(i64, usize)> {
     let (mut u, used) = unpack_u64_dyn(data)?;
     let neg = (u >> 6) & 1;
     u = ((u >> 1) & !0x3f) | (u & 0x3f);
-    let v = if neg != 0 {
-        if u == 0 {
-            (1i64) << 63
-        } else {
-            -(u as i64)
-        }
-    } else {
-        u as i64
-    };
+    let mut v = u as i64;
+    if neg != 0 {
+        v = (!(u.wrapping_sub(1)) | (1u64 << 63)) as i64;
+    }
     Some((v, used))
 }
 


### PR DESCRIPTION
## Summary
- use bitwise complement to encode negative i64 values: `(~v + 1) & ~(1 << 63)`
- remove special-case branch when decoding by applying `~(v - 1) | (1 << 63)`
- apply the new scheme across all language implementations and update docs

## Testing
- `gcc -std=c99 -Wall -Wextra -Werror test.c u64_dyn.c -o test && ./test`
- `g++ -std=c++17 -Wall -Wextra -Werror test.cpp -o test && ./test`
- `go test ./...`
- `node test.js`
- `python3 test.py`
- `lua test.lua`
- `php test.php`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_689a1a5928788325b42b3f925175d6b2