### PR TITLE
Ensure unpack is modulo 2^64

### DIFF
--- a/c/test.c
+++ b/c/test.c
@@ -115,5 +115,15 @@ int main()
             assert(!unpack_u64_dyn_v2(bads[i].d, bads[i].s, &u, &used));
         }
     }
+    {
+        const uint8_t enc[] = { 0xFF, 0xFF, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE };
+        uint64_t u;
+        int64_t v;
+        size_t used;
+        assert(unpack_u64_dyn_v2(enc, sizeof(enc), &u, &used));
+        assert(u == 0x7F && used == sizeof(enc));
+        assert(unpack_i64_dyn_v2(enc, sizeof(enc), &v, &used));
+        assert(v == -64 && used == sizeof(enc));
+    }
     return 0;
 }

--- a/cpp/test.cpp
+++ b/cpp/test.cpp
@@ -113,5 +113,11 @@ int main()
             assert(threw);
         }
     }
+    {
+        const uint8_t enc[] = { 0xFF, 0xFF, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE };
+        size_t used;
+        assert(unpack_u64_dyn<2>(enc, sizeof(enc), &used) == 0x7F && used == sizeof(enc));
+        assert(unpack_i64_dyn<2>(enc, sizeof(enc), &used) == -64 && used == sizeof(enc));
+    }
     return 0;
 }

--- a/go/u64_dyn_test.go
+++ b/go/u64_dyn_test.go
@@ -126,3 +126,15 @@ func TestTruncated(t *testing.T) {
         }
     }
 }
+
+func TestWrapModulo64(t *testing.T) {
+    enc := []byte{0xFF, 0xFF, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE}
+    v, off, err := UnpackU64DynV2(enc, 0)
+    if err != nil || v != 0x7F || off != len(enc) {
+        t.Fatalf("UnpackU64DynV2 modulo check failed: (%d,%d,%v)", v, off, err)
+    }
+    sv, off, err := UnpackI64DynV2(enc, 0)
+    if err != nil || sv != -64 || off != len(enc) {
+        t.Fatalf("UnpackI64DynV2 modulo check failed: (%d,%d,%v)", sv, off, err)
+    }
+}

--- a/js/test.js
+++ b/js/test.js
@@ -98,7 +98,6 @@ for (const enc of truncatedCases) {
   expectThrow(() => unpack_u64_dyn_v2(buf), 'unpack_u64_dyn_v2 should throw on insufficient data');
 }
 
-// Since JS needs bigint for 64-bit integers, we also need to be sure it unpack is modulo 2^64 for contrived inputs
 {
   const enc = Uint8Array.from([0xff, 0xff, 0xfe, 0xfe, 0xfe, 0xfe, 0xfe, 0xfe, 0xfe]);
   assert.deepStrictEqual(unpack_u64_dyn_v2(enc), [0x7fn, 9], 'unpack_u64_dyn_v2 should wrap modulo 2^64');

--- a/lua/test.lua
+++ b/lua/test.lua
@@ -58,3 +58,13 @@ for _, enc in pairs({ "", "\x80", "\x80\x80\x80\x80\x80\x80\x80\x80" }) do
     assert(not pcall(unpack_i64_dyn_v2, enc))
     assert(not pcall(unpack_u64_dyn_v2, enc))
 end
+
+do
+    local enc = "\xFF\xFF\xFE\xFE\xFE\xFE\xFE\xFE\xFE"
+    local v, off = unpack_u64_dyn_v2(enc)
+    assert(v == 0x7F)
+    assert(off == #enc + 1)
+    local sv, off2 = unpack_i64_dyn_v2(enc)
+    assert(sv == -64)
+    assert(off2 == #enc + 1)
+end

--- a/php/test.php
+++ b/php/test.php
@@ -101,3 +101,11 @@ foreach ($incomplete as $enc)
         assert(false);
     } catch (Exception $e) {}
 }
+
+$enc = "\xFF\xFF\xFE\xFE\xFE\xFE\xFE\xFE\xFE";
+$offset = 0;
+assert(unpack_u64_dyn_v2($enc, $offset) == 0x7F);
+assert($offset == strlen($enc));
+$offset = 0;
+assert(unpack_i64_dyn_v2($enc, $offset) == -64);
+assert($offset == strlen($enc));

--- a/python/test.py
+++ b/python/test.py
@@ -88,6 +88,11 @@ class U64DynTests(unittest.TestCase):
             with self.assertRaises(ValueError):
                 unpack_i64_dyn_v2(enc)
 
+    def test_wrap_mod_64(self):
+        enc = bytes([0xFF, 0xFF, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE])
+        self.assertEqual(unpack_u64_dyn_v2(enc), (0x7F, 9))
+        self.assertEqual(unpack_i64_dyn_v2(enc), (-64, 9))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/u64_dyn.py
+++ b/python/u64_dyn.py
@@ -50,14 +50,14 @@ def unpack_u64_dyn(buf: bytes, offset: int = 0) -> Tuple[int, int]:
         v += (b & 0x7F) << bits
         used += 1
         if (b & 0x80) == 0:
-            return v, offset + used
+            return v & ((1 << 64) - 1), offset + used
         bits += 7
     if offset + used >= length:
         raise ValueError('Insufficient data')
     b = buf[offset + used]
     v += b << 56
     used += 1
-    return v, offset + used
+    return v & ((1 << 64) - 1), offset + used
 
 
 # u64_dyn_v2 ----------------------------------------------------------------
@@ -97,7 +97,7 @@ def unpack_u64_dyn_v2(buf: bytes, offset: int = 0) -> Tuple[int, int]:
         v += (b & 0x7F) << bits
         used += 1
         if (b & 0x80) == 0:
-            return v, offset + used
+            return v & ((1 << 64) - 1), offset + used
         bits += 7
         v += 1 << bits # v2
     if offset + used >= length:
@@ -105,7 +105,7 @@ def unpack_u64_dyn_v2(buf: bytes, offset: int = 0) -> Tuple[int, int]:
     b = buf[offset + used]
     v += b << 56
     used += 1
-    return v, offset + used
+    return v & ((1 << 64) - 1), offset + used
 
 
 # i64_dyn -------------------------------------------------------------------

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -27,10 +27,10 @@ pub fn unpack_u64_dyn(data: &[u8]) -> Option<(u64, usize)> {
         let b = data[used] as u64;
         used += 1;
         if used == 9 {
-            v += b << bits;
+            v = v.wrapping_add(b << bits);
             break;
         }
-        v += (b & 0x7f) << bits;
+        v = v.wrapping_add((b & 0x7f) << bits);
         if (b & 0x80) == 0 {
             break;
         }
@@ -69,15 +69,15 @@ pub fn unpack_u64_dyn_v2(data: &[u8]) -> Option<(u64, usize)> {
         let b = data[used] as u64;
         used += 1;
         if used == 9 {
-            v += b << bits;
+            v = v.wrapping_add(b << bits);
             break;
         }
-        v += (b & 0x7f) << bits;
+        v = v.wrapping_add((b & 0x7f) << bits);
         if (b & 0x80) == 0 {
             break;
         }
         bits += 7;
-        v += 1u64 << bits; // v2
+        v = v.wrapping_add(1u64 << bits); // v2
     }
     Some((v, used))
 }

--- a/rust/tests.rs
+++ b/rust/tests.rs
@@ -82,3 +82,10 @@ fn test_truncated() {
         assert!(unpack_u64_dyn_v2(&enc).is_none());
     }
 }
+
+#[test]
+fn test_wrap_mod_64() {
+    let enc = vec![0xff, 0xff, 0xfe, 0xfe, 0xfe, 0xfe, 0xfe, 0xfe, 0xfe];
+    assert_eq!(unpack_u64_dyn_v2(&enc), Some((0x7f, 9)));
+    assert_eq!(unpack_i64_dyn_v2(&enc), Some((-64, 9)));
+}


### PR DESCRIPTION
## Summary
- mask `unpack_u64_dyn` and `unpack_u64_dyn_v2` results to 64 bits
- add tests to confirm unpacking wraps modulo 2^64 for contrived inputs

## Testing
- `python3 python/test.py`

------
https://chatgpt.com/codex/tasks/task_e_689a2f15dca48325b39e2893a8b19c20