### PR TITLE
go: require caller-provided buffer for packing

### DIFF
--- a/go/u64_dyn.go
+++ b/go/u64_dyn.go
@@ -2,23 +2,25 @@ package u64dyn
 
 import "errors"
 
-// PackU64Dyn packs an integer into u64_dyn bytes.
-func PackU64Dyn(v uint64) []byte {
-	out := make([]byte, 0, 9)
-	for i := 0; i < 8; i++ {
+// PackU64Dyn packs an integer into buf using u64_dyn encoding and
+// returns the number of bytes written.
+func PackU64Dyn(buf []byte, v uint64) int {
+	i := 0
+	for ; i < 8; i++ {
 		cur := byte(v & 0x7f)
 		v >>= 7
 		if v != 0 {
-			out = append(out, cur|0x80)
+			buf[i] = cur | 0x80
 		} else {
-			out = append(out, cur)
-			return out
+			buf[i] = cur
+			return i + 1
 		}
 	}
 	if v != 0 {
-		out = append(out, byte(v))
+		buf[i] = byte(v)
+		i++
 	}
-	return out
+	return i
 }
 
 // UnpackU64Dyn unpacks a u64_dyn encoded integer from buf starting at offset.
@@ -48,24 +50,26 @@ func UnpackU64Dyn(buf []byte, offset int) (uint64, int, error) {
 	return v, offset + used, nil
 }
 
-// PackU64DynV2 packs an integer using u64_dyn_v2.
-func PackU64DynV2(v uint64) []byte {
-	out := make([]byte, 0, 9)
-	for i := 0; i < 8; i++ {
+// PackU64DynV2 packs an integer into buf using u64_dyn_v2 encoding and
+// returns the number of bytes written.
+func PackU64DynV2(buf []byte, v uint64) int {
+	i := 0
+	for ; i < 8; i++ {
 		cur := byte(v & 0x7f)
 		v >>= 7
 		if v != 0 {
-			out = append(out, cur|0x80)
+			buf[i] = cur | 0x80
 			v-- // v2
 		} else {
-			out = append(out, cur)
-			return out
+			buf[i] = cur
+			return i + 1
 		}
 	}
 	if v != 0 {
-		out = append(out, byte(v))
+		buf[i] = byte(v)
+		i++
 	}
-	return out
+	return i
 }
 
 // UnpackU64DynV2 unpacks a u64_dyn_v2 encoded integer from buf starting at offset.
@@ -96,8 +100,9 @@ func UnpackU64DynV2(buf []byte, offset int) (uint64, int, error) {
 	return v, offset + used, nil
 }
 
-// PackI64Dyn packs a signed integer using i64_dyn.
-func PackI64Dyn(v int64) []byte {
+// PackI64Dyn packs a signed integer into buf using i64_dyn encoding and
+// returns the number of bytes written.
+func PackI64Dyn(buf []byte, v int64) int {
 	var u uint64 = uint64(v)
 	neg := uint64(0)
 	if v < 0 {
@@ -105,7 +110,7 @@ func PackI64Dyn(v int64) []byte {
 		u = (^u + 1) & ^(uint64(1) << 63)
 	}
 	packed := (neg << 6) | ((u & ^uint64(0x3f)) << 1) | (u & 0x3f)
-	return PackU64Dyn(packed)
+	return PackU64Dyn(buf, packed)
 }
 
 // UnpackI64Dyn unpacks an i64_dyn encoded integer from buf starting at offset.
@@ -124,8 +129,9 @@ func UnpackI64Dyn(buf []byte, offset int) (int64, int, error) {
 	return v, idx, nil
 }
 
-// PackI64DynV2 packs a signed integer using i64_dyn_v2.
-func PackI64DynV2(v int64) []byte {
+// PackI64DynV2 packs a signed integer into buf using i64_dyn_v2 encoding and
+// returns the number of bytes written.
+func PackI64DynV2(buf []byte, v int64) int {
 	var u uint64
 	var neg uint64
 	if v < 0 {
@@ -135,7 +141,7 @@ func PackI64DynV2(v int64) []byte {
 		u = uint64(v)
 	}
 	packed := (neg << 6) | ((u & ^uint64(0x3f)) << 1) | (u & 0x3f)
-	return PackU64DynV2(packed)
+	return PackU64DynV2(buf, packed)
 }
 
 // UnpackI64DynV2 unpacks an i64_dyn_v2 encoded integer from buf starting at offset.

--- a/go/u64_dyn_test.go
+++ b/go/u64_dyn_test.go
@@ -16,8 +16,9 @@ func TestPackUnpackU64(t *testing.T) {
 		0x8000000000000000: {0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80},
 	}
 	for val, enc := range cases {
-		got := PackU64Dyn(val)
-		if !bytes.Equal(got, enc) {
+		buf := make([]byte, 9)
+		n := PackU64Dyn(buf, val)
+		if got := buf[:n]; !bytes.Equal(got, enc) {
 			t.Errorf("PackU64Dyn(%d) = %v, want %v", val, got, enc)
 		}
 		v, off, err := UnpackU64Dyn(enc, 0)
@@ -41,8 +42,9 @@ func TestPackUnpackI64(t *testing.T) {
 		-0x8000000000000000: {0x40},
 	}
 	for val, enc := range cases {
-		got := PackI64Dyn(val)
-		if !bytes.Equal(got, enc) {
+		buf := make([]byte, 9)
+		n := PackI64Dyn(buf, val)
+		if got := buf[:n]; !bytes.Equal(got, enc) {
 			t.Errorf("PackI64Dyn(%d) = %v, want %v", val, got, enc)
 		}
 		v, off, err := UnpackI64Dyn(enc, 0)
@@ -66,8 +68,9 @@ func TestPackUnpackU64V2(t *testing.T) {
 		0x8000000000000000: {0x80, 0xFF, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0x7E},
 	}
 	for val, enc := range cases {
-		got := PackU64DynV2(val)
-		if !bytes.Equal(got, enc) {
+		buf := make([]byte, 9)
+		n := PackU64DynV2(buf, val)
+		if got := buf[:n]; !bytes.Equal(got, enc) {
 			t.Errorf("PackU64DynV2(%d) = %v, want %v", val, got, enc)
 		}
 		v, off, err := UnpackU64DynV2(enc, 0)
@@ -91,8 +94,9 @@ func TestPackUnpackI64V2(t *testing.T) {
 		-0x8000000000000000: {0xFF, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE},
 	}
 	for val, enc := range cases {
-		got := PackI64DynV2(val)
-		if !bytes.Equal(got, enc) {
+		buf := make([]byte, 9)
+		n := PackI64DynV2(buf, val)
+		if got := buf[:n]; !bytes.Equal(got, enc) {
 			t.Errorf("PackI64DynV2(%d) = %v, want %v", val, got, enc)
 		}
 		v, off, err := UnpackI64DynV2(enc, 0)


### PR DESCRIPTION
## Summary
- require callers to supply a buffer for Go packing helpers and return bytes written
- update tests for new packing API

## Testing
- `cd go && go test`


------
https://chatgpt.com/codex/tasks/task_e_689a4c93a7248325bff7557f799de4ed