### PR TITLE
[Lua] Implement u64_dyn_p

### DIFF
--- a/lua/test.lua
+++ b/lua/test.lua
@@ -15,6 +15,21 @@ end
 
 for val, enc in pairs({
     [0] = "\x00",
+    [0x7f] = "\x7F",
+    [0x80] = "\x80\x02",
+    [1337] = "\xB9\x14",
+    [42069] = "\xD5\x22\x05",
+    [0xffffffffffffffff] = "\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF",
+    [0x8000000000000000] = "\xFF\x00\x00\x00\x00\x00\x00\x00\x80",
+}) do
+    assert(pack_u64_dyn_p(val) == enc)
+    local v, off = unpack_u64_dyn_p(enc)
+    assert(v == val)
+    assert(off == #enc + 1)
+end
+
+for val, enc in pairs({
+    [0] = "\x00",
     [0x7f] = "\xBF\x01",
     [0x80] = "\x80\x02",
     [1337] = "\xB9\x14",
@@ -58,6 +73,10 @@ for _, enc in pairs({ "", "\x80", "\x80\x80\x80\x80\x80\x80\x80\x80" }) do
     assert(not pcall(unpack_i64_dyn_a, enc))
     assert(not pcall(unpack_i64_dyn_b, enc))
     assert(not pcall(unpack_u64_dyn_b, enc))
+end
+
+for _, enc in pairs({ "\xFF\x00\x00\x00\x00\x00\x00\x00" }) do
+    assert(not pcall(unpack_u64_dyn_p, enc))
 end
 
 do

--- a/lua/u64_dyn.lua
+++ b/lua/u64_dyn.lua
@@ -66,9 +66,6 @@ end
 function unpack_u64_dyn_p(str, i)
     i = i or 1
     local first_byte = str:byte(i)
-    if not first_byte then
-        error("unpack_u64_dyn_p: input too short")
-    end
 
     local prefix_bits = 0
     while prefix_bits < 8 and (first_byte & (0x80 >> prefix_bits)) ~= 0 do
@@ -77,10 +74,6 @@ function unpack_u64_dyn_p(str, i)
 
     local byte_length = prefix_bits + 1
     local first_byte_value_bits = byte_length < 8 and (8 - byte_length) or 0
-
-    if (#str - i + 1) < byte_length then
-        error("unpack_u64_dyn_p: input too short")
-    end
 
     local v = 0
     for idx = 1, byte_length - 1 do

--- a/lua/u64_dyn.lua
+++ b/lua/u64_dyn.lua
@@ -31,9 +31,7 @@ function unpack_u64_dyn(str, i)
     return v, i
 end
 
-function pack_u64_dyn_p(v)
-    local u = v & 0xffffffffffffffff
-
+function pack_u64_dyn_p(u)
     local byte_length = 1
     if not math.ult(u, 1 << 7) then byte_length = byte_length + 1 end
     if not math.ult(u, 1 << 14) then byte_length = byte_length + 1 end

--- a/lua/u64_dyn.lua
+++ b/lua/u64_dyn.lua
@@ -31,6 +31,69 @@ function unpack_u64_dyn(str, i)
     return v, i
 end
 
+function pack_u64_dyn_p(v)
+    local u = v & 0xffffffffffffffff
+
+    local byte_length = 1
+    if not math.ult(u, 1 << 7) then byte_length = byte_length + 1 end
+    if not math.ult(u, 1 << 14) then byte_length = byte_length + 1 end
+    if not math.ult(u, 1 << 21) then byte_length = byte_length + 1 end
+    if not math.ult(u, 1 << 28) then byte_length = byte_length + 1 end
+    if not math.ult(u, 1 << 35) then byte_length = byte_length + 1 end
+    if not math.ult(u, 1 << 42) then byte_length = byte_length + 1 end
+    if not math.ult(u, 1 << 49) then byte_length = byte_length + 1 end
+    if not math.ult(u, 1 << 56) then byte_length = byte_length + 1 end
+
+    local first_byte_value_bits = byte_length < 8 and (8 - byte_length) or 0
+    local first_byte_prefix_bits = byte_length - 1
+
+    local prefix_mask = 0
+    for bit = 1, first_byte_prefix_bits do
+        prefix_mask = prefix_mask | (1 << (8 - bit))
+    end
+
+    local value_mask = first_byte_value_bits == 0 and 0 or ((1 << first_byte_value_bits) - 1)
+    local first_byte = (prefix_mask | (u & value_mask)) & 0xff
+    u = u >> first_byte_value_bits
+
+    local out = { string.char(first_byte) }
+    for idx = 1, byte_length - 1 do
+        out[#out + 1] = string.char((u >> ((idx - 1) * 8)) & 0xff)
+    end
+    return table.concat(out)
+end
+
+function unpack_u64_dyn_p(str, i)
+    i = i or 1
+    local first_byte = str:byte(i)
+    if not first_byte then
+        error("unpack_u64_dyn_p: input too short")
+    end
+
+    local prefix_bits = 0
+    while prefix_bits < 8 and (first_byte & (0x80 >> prefix_bits)) ~= 0 do
+        prefix_bits = prefix_bits + 1
+    end
+
+    local byte_length = prefix_bits + 1
+    local first_byte_value_bits = byte_length < 8 and (8 - byte_length) or 0
+
+    if (#str - i + 1) < byte_length then
+        error("unpack_u64_dyn_p: input too short")
+    end
+
+    local v = 0
+    for idx = 1, byte_length - 1 do
+        local b = str:byte(i + idx)
+        v = v | (b << ((idx - 1) * 8))
+    end
+    v = v << first_byte_value_bits
+    local value_mask = first_byte_value_bits == 0 and 0 or ((1 << first_byte_value_bits) - 1)
+    v = v | (first_byte & value_mask)
+
+    return v, i + byte_length
+end
+
 function pack_i64_dyn_a(v)
     local neg = (v >> 63)
     if v < 0 then


### PR DESCRIPTION
## Summary
- implement Lua versions of `pack_u64_dyn_p` and `unpack_u64_dyn_p` mirroring the C reference
- expand the Lua test suite with coverage for the prefix-based unsigned encoding, including an invalid case

## Testing
- LUA_PATH='lua/?.lua;;' lua lua/test.lua

------
https://chatgpt.com/codex/tasks/task_e_6900ebc3c17883259bb16f6e05d17eb6