### PR TITLE
[PHP] Implement u64_dyn_p

### DIFF
--- a/lua/test.lua
+++ b/lua/test.lua
@@ -75,7 +75,7 @@ for _, enc in pairs({ "", "\x80", "\x80\x80\x80\x80\x80\x80\x80\x80" }) do
     assert(not pcall(unpack_u64_dyn_b, enc))
 end
 
-for _, enc in pairs({ "\xFF\x00\x00\x00\x00\x00\x00\x00" }) do
+for _, enc in pairs({ "", "\x80", "\xFF\x00\x00\x00\x00\x00\x00\x00" }) do
     assert(not pcall(unpack_u64_dyn_p, enc))
 end
 

--- a/lua/u64_dyn.lua
+++ b/lua/u64_dyn.lua
@@ -45,13 +45,7 @@ function pack_u64_dyn_p(u)
     local first_byte_value_bits = byte_length < 8 and (8 - byte_length) or 0
     local first_byte_prefix_bits = byte_length - 1
 
-    local prefix_mask = 0
-    for bit = 1, first_byte_prefix_bits do
-        prefix_mask = prefix_mask | (1 << (8 - bit))
-    end
-
-    local value_mask = first_byte_value_bits == 0 and 0 or ((1 << first_byte_value_bits) - 1)
-    local first_byte = (prefix_mask | (u & value_mask)) & 0xff
+    local first_byte = ((0xff << (8 - first_byte_prefix_bits)) & 0xff) | (u & ((1 << first_byte_value_bits) - 1))
     u = u >> first_byte_value_bits
 
     local out = { string.char(first_byte) }

--- a/php/test.php
+++ b/php/test.php
@@ -26,7 +26,6 @@ $tests_u64 = [
     0x123456789ABCDEF => "\xFF\xEF\xCD\xAB\x89\x67\x45\x23\x01",
     -1 => "\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF",
 ];
-
 foreach ($tests_u64 as $val => $enc)
 {
     assert(pack_u64_dyn_p($val) == $enc);
@@ -34,6 +33,7 @@ foreach ($tests_u64 as $val => $enc)
     assert(unpack_u64_dyn_p($enc, $offset) == $val);
     assert($offset == strlen($enc));
 }
+
 $tests_u64 = [
     0 => "\x00",
     0x7f => "\x7F",

--- a/php/test.php
+++ b/php/test.php
@@ -22,6 +22,23 @@ foreach ($tests_u64 as $val => $enc)
 $tests_u64 = [
     0 => "\x00",
     0x7f => "\x7F",
+    0x80 => "\x80\x02",
+    0x4000 => "\xC0\x00\x02",
+    0x123456789ABCDEF => "\xFF\xEF\xCD\xAB\x89\x67\x45\x23\x01",
+    -1 => "\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF",
+];
+
+foreach ($tests_u64 as $val => $enc)
+{
+    assert(pack_u64_dyn_p($val) == $enc);
+    $offset = 0;
+    assert(unpack_u64_dyn_p($enc, $offset) == $val);
+    assert($offset == strlen($enc));
+}
+
+$tests_u64 = [
+    0 => "\x00",
+    0x7f => "\x7F",
     0x80 => "\x80\x00",
     1337 => "\xB9\x09",
     42069 => "\xD5\xC7\x01",
@@ -74,7 +91,7 @@ foreach ($tests_i64 as $val => $enc)
     assert($offset == strlen($enc));
 }
 
-$incomplete = [ "", "\x80", "\x80\x80\x80\x80\x80\x80\x80\x80" ];
+$incomplete = [ "", "\x80", "\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF" ];
 
 foreach ($incomplete as $enc)
 {
@@ -93,6 +110,12 @@ foreach ($incomplete as $enc)
     try {
         $offset = 0;
         unpack_u64_dyn_b($enc, $offset);
+        assert(false);
+    } catch (Exception $e) {}
+
+    try {
+        $offset = 0;
+        unpack_u64_dyn_p($enc, $offset);
         assert(false);
     } catch (Exception $e) {}
 

--- a/php/test.php
+++ b/php/test.php
@@ -10,7 +10,6 @@ $tests_u64 = [
     -1 => "\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF",
     -9223372036854775808 => "\x80\x80\x80\x80\x80\x80\x80\x80\x80",
 ];
-
 foreach ($tests_u64 as $val => $enc)
 {
     assert(pack_u64_dyn($val) == $enc);
@@ -35,7 +34,6 @@ foreach ($tests_u64 as $val => $enc)
     assert(unpack_u64_dyn_p($enc, $offset) == $val);
     assert($offset == strlen($enc));
 }
-
 $tests_u64 = [
     0 => "\x00",
     0x7f => "\x7F",
@@ -46,7 +44,6 @@ $tests_u64 = [
     -1 => "\xFF\xFE\xFE\xFE\xFE\xFE\xFE\xFE\xFE",
     -9223372036854775808 => "\x80\xFF\xFE\xFE\xFE\xFE\xFE\xFE\x7E",
 ];
-
 foreach ($tests_u64 as $val => $enc)
 {
     assert(pack_u64_dyn_b($val) == $enc);
@@ -64,7 +61,6 @@ $tests_i64 = [
     -1 => "\x41",
     PHP_INT_MIN => "\x40",
 ];
-
 foreach ($tests_i64 as $val => $enc)
 {
     assert(pack_i64_dyn_a($val) == $enc);
@@ -82,7 +78,6 @@ $tests_i64 = [
     -1 => "\x40",
     -9223372036854775808 => "\xFF\xFE\xFE\xFE\xFE\xFE\xFE\xFE\xFE",
 ];
-
 foreach ($tests_i64 as $val => $enc)
 {
     assert(pack_i64_dyn_b($val) == $enc);
@@ -91,8 +86,7 @@ foreach ($tests_i64 as $val => $enc)
     assert($offset == strlen($enc));
 }
 
-$incomplete = [ "", "\x80", "\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF" ];
-
+$incomplete = [ "", "\x80", "\x80\x80\x80\x80\x80\x80\x80\x80" ];
 foreach ($incomplete as $enc)
 {
     try {
@@ -115,13 +109,17 @@ foreach ($incomplete as $enc)
 
     try {
         $offset = 0;
-        unpack_u64_dyn_p($enc, $offset);
+        unpack_i64_dyn_b($enc, $offset);
         assert(false);
     } catch (Exception $e) {}
+}
 
+$incomplete_p = [ "", "\x80", "\xFF\x00\x00\x00\x00\x00\x00\x00" ];
+foreach ($incomplete_p as $enc)
+{
     try {
         $offset = 0;
-        unpack_i64_dyn_b($enc, $offset);
+        unpack_u64_dyn_p($enc, $offset);
         assert(false);
     } catch (Exception $e) {}
 }

--- a/php/u64_dyn.php
+++ b/php/u64_dyn.php
@@ -85,21 +85,8 @@ function pack_u64_dyn_p($v)
     $first_byte_value_bits = $byte_length < 8 ? 8 - $byte_length : 0;
     $first_byte_prefix_bits = $byte_length - 1;
 
-    if ($first_byte_prefix_bits == 0)
-    {
-        $prefix = 0;
-    }
-    else
-    {
-        $prefix = ((1 << $first_byte_prefix_bits) - 1) << (8 - $first_byte_prefix_bits);
-    }
-
-    $value_mask = $first_byte_value_bits == 0 ? 0 : ((1 << $first_byte_value_bits) - 1);
-    $first_byte = ($prefix | ($v & $value_mask)) & 0xff;
-    if ($first_byte_value_bits != 0)
-    {
-        $v >>= $first_byte_value_bits;
-    }
+    $first_byte = ((0xff << (8 - $first_byte_prefix_bits)) & 0xff) | ($v & ((1 << $first_byte_value_bits) - 1));
+    $v >>= $first_byte_value_bits;
 
     $out = chr($first_byte);
     for ($idx = 1; $idx < $byte_length; ++$idx)

--- a/php/u64_dyn.php
+++ b/php/u64_dyn.php
@@ -128,11 +128,8 @@ function unpack_u64_dyn_p($str, &$offset = 0)
         $v |= $b << (($idx - 1) * 8);
     }
 
-    if ($first_byte_value_bits != 0)
-    {
-        $v <<= $first_byte_value_bits;
-        $v |= $first_byte & ((1 << $first_byte_value_bits) - 1);
-    }
+    $v <<= $first_byte_value_bits;
+    $v |= $first_byte & ((1 << $first_byte_value_bits) - 1);
 
     $offset += $byte_length;
     return $v;

--- a/php/u64_dyn.php
+++ b/php/u64_dyn.php
@@ -122,7 +122,7 @@ function unpack_u64_dyn_p($str, &$offset = 0)
     }
 
     $v = 0;
-    for ($idx = 1; $idx < $byte_length; ++$idx)
+    for ($idx = 1; $idx != $byte_length; ++$idx)
     {
         $b = ord($str[$offset + $idx]);
         $v |= $b << (($idx - 1) * 8);

--- a/php/u64_dyn.php
+++ b/php/u64_dyn.php
@@ -65,6 +65,92 @@ function unpack_u64_dyn($str, &$offset = 0)
     return $v;
 }
 
+function pack_u64_dyn_p($v)
+{
+    if (is_float($v))
+    {
+        throw new Exception("Cannot encode a float as u64");
+    }
+
+    $byte_length = 1;
+    if (($v >> 7) != 0) { $byte_length += 1; }
+    if (($v >> 14) != 0) { $byte_length += 1; }
+    if (($v >> 21) != 0) { $byte_length += 1; }
+    if (($v >> 28) != 0) { $byte_length += 1; }
+    if (($v >> 35) != 0) { $byte_length += 1; }
+    if (($v >> 42) != 0) { $byte_length += 1; }
+    if (($v >> 49) != 0) { $byte_length += 1; }
+    if (($v >> 56) != 0) { $byte_length += 1; }
+
+    $first_byte_value_bits = $byte_length < 8 ? 8 - $byte_length : 0;
+    $first_byte_prefix_bits = $byte_length - 1;
+
+    if ($first_byte_prefix_bits == 0)
+    {
+        $prefix = 0;
+    }
+    else
+    {
+        $prefix = ((1 << $first_byte_prefix_bits) - 1) << (8 - $first_byte_prefix_bits);
+    }
+
+    $value_mask = $first_byte_value_bits == 0 ? 0 : ((1 << $first_byte_value_bits) - 1);
+    $first_byte = ($prefix | ($v & $value_mask)) & 0xff;
+    if ($first_byte_value_bits != 0)
+    {
+        $v >>= $first_byte_value_bits;
+    }
+
+    $out = chr($first_byte);
+    for ($idx = 1; $idx < $byte_length; ++$idx)
+    {
+        $out .= chr(($v >> (($idx - 1) * 8)) & 0xff);
+    }
+
+    return $out;
+}
+
+function unpack_u64_dyn_p($str, &$offset = 0)
+{
+    $len = strlen($str);
+    if ($offset >= $len)
+    {
+        throw new Exception("Insufficient data");
+    }
+
+    $first_byte = ord($str[$offset]);
+
+    $prefix_bits = 0;
+    while ($prefix_bits < 8 && ($first_byte & (0x80 >> $prefix_bits)) != 0)
+    {
+        $prefix_bits += 1;
+    }
+
+    $byte_length = $prefix_bits + 1;
+    $first_byte_value_bits = $byte_length < 8 ? 8 - $byte_length : 0;
+
+    if ($offset + $byte_length > $len)
+    {
+        throw new Exception("Insufficient data");
+    }
+
+    $v = 0;
+    for ($idx = 1; $idx < $byte_length; ++$idx)
+    {
+        $b = ord($str[$offset + $idx]);
+        $v |= $b << (($idx - 1) * 8);
+    }
+
+    if ($first_byte_value_bits != 0)
+    {
+        $v <<= $first_byte_value_bits;
+        $v |= $first_byte & ((1 << $first_byte_value_bits) - 1);
+    }
+
+    $offset += $byte_length;
+    return $v;
+}
+
 function pack_u64_dyn_b($v)
 {
     if (is_float($v))


### PR DESCRIPTION
## Summary
- implement `pack_u64_dyn_p` and `unpack_u64_dyn_p` in the PHP runtime
- expand PHP unit tests to exercise the new codec and its error handling

## Testing
- php php/test.php

------
https://chatgpt.com/codex/tasks/task_e_6900f05f6c388325af8f5729ff732a09