### PR TITLE
[PHP] Implement u64_dyn_bp & i64_dyn_bp

### DIFF
--- a/php/test.php
+++ b/php/test.php
@@ -52,6 +52,24 @@ foreach ($tests_u64 as $val => $enc)
     assert($offset == strlen($enc));
 }
 
+$tests_u64 = [
+    0 => "\x00",
+    0x7f => "\x7F",
+    0x80 => "\x80\x00",
+    1337 => "\xB9\x12",
+    42069 => "\xD5\x1E\x03",
+    0x123456789ABCDEF => "\xFF\x6F\x8D\x8B\x79\x5F\x41\x21\x00",
+    -1 => "\xFF\x7F\xBF\xDF\xEF\xF7\xFB\xFD\xFE",
+    -9223372036854775808 => "\xFF\x80\xBF\xDF\xEF\xF7\xFB\xFD\x7E",
+];
+foreach ($tests_u64 as $val => $enc)
+{
+    assert(pack_u64_dyn_bp($val) == $enc);
+    $offset = 0;
+    assert(unpack_u64_dyn_bp($enc, $offset) == $val);
+    assert($offset == strlen($enc));
+}
+
 $tests_i64 = [
     0 => "\x00",
     0x7f => "\xBF\x01",
@@ -86,6 +104,23 @@ foreach ($tests_i64 as $val => $enc)
     assert($offset == strlen($enc));
 }
 
+$tests_i64 = [
+    0 => "\x00",
+    0x7f => "\xBF\x00",
+    0x80 => "\x80\x02",
+    1337 => "\xB9\x26",
+    42069 => "\xD5\x40\x08",
+    -1 => "\x40",
+    -9223372036854775808 => "\xFF\x7F\xBF\xDF\xEF\xF7\xFB\xFD\xFE",
+];
+foreach ($tests_i64 as $val => $enc)
+{
+    assert(pack_i64_dyn_bp($val) == $enc);
+    $offset = 0;
+    assert(unpack_i64_dyn_bp($enc, $offset) == $val);
+    assert($offset == strlen($enc));
+}
+
 $incomplete = [ "", "\x80", "\x80\x80\x80\x80\x80\x80\x80\x80" ];
 foreach ($incomplete as $enc)
 {
@@ -112,6 +147,7 @@ foreach ($incomplete as $enc)
         unpack_i64_dyn_b($enc, $offset);
         assert(false);
     } catch (Exception $e) {}
+
 }
 
 $incomplete_p = [ "", "\x80", "\xFF\x00\x00\x00\x00\x00\x00\x00" ];
@@ -120,6 +156,18 @@ foreach ($incomplete_p as $enc)
     try {
         $offset = 0;
         unpack_u64_dyn_p($enc, $offset);
+        assert(false);
+    } catch (Exception $e) {}
+
+    try {
+        $offset = 0;
+        unpack_u64_dyn_bp($enc, $offset);
+        assert(false);
+    } catch (Exception $e) {}
+
+    try {
+        $offset = 0;
+        unpack_i64_dyn_bp($enc, $offset);
         assert(false);
     } catch (Exception $e) {}
 }
@@ -132,6 +180,16 @@ try {
 } catch (Exception $e) {}
 try {
     $offset = 0;
+    unpack_u64_dyn_bp($enc, $offset);
+    assert(false);
+} catch (Exception $e) {}
+try {
+    $offset = 0;
     unpack_i64_dyn_b($enc, $offset);
+    assert(false);
+} catch (Exception $e) {}
+try {
+    $offset = 0;
+    unpack_i64_dyn_bp($enc, $offset);
     assert(false);
 } catch (Exception $e) {}

--- a/php/test.php
+++ b/php/test.php
@@ -147,7 +147,6 @@ foreach ($incomplete as $enc)
         unpack_i64_dyn_b($enc, $offset);
         assert(false);
     } catch (Exception $e) {}
-
 }
 
 $incomplete_p = [ "", "\x80", "\xFF\x00\x00\x00\x00\x00\x00\x00" ];

--- a/php/test.php
+++ b/php/test.php
@@ -1,7 +1,7 @@
 <?php
 require_once __DIR__ . '/u64_dyn.php';
 
-$tests_u64 = [
+$tests = [
     0 => "\x00",
     0x7f => "\x7F",
     0x80 => "\x80\x01",
@@ -10,7 +10,7 @@ $tests_u64 = [
     -1 => "\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF",
     -9223372036854775808 => "\x80\x80\x80\x80\x80\x80\x80\x80\x80",
 ];
-foreach ($tests_u64 as $val => $enc)
+foreach ($tests as $val => $enc)
 {
     assert(pack_u64_dyn($val) == $enc);
     $offset = 0;
@@ -18,23 +18,7 @@ foreach ($tests_u64 as $val => $enc)
     assert($offset == strlen($enc));
 }
 
-$tests_u64 = [
-    0 => "\x00",
-    0x7f => "\x7F",
-    0x80 => "\x80\x02",
-    0x4000 => "\xC0\x00\x02",
-    0x123456789ABCDEF => "\xFF\xEF\xCD\xAB\x89\x67\x45\x23\x01",
-    -1 => "\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF",
-];
-foreach ($tests_u64 as $val => $enc)
-{
-    assert(pack_u64_dyn_p($val) == $enc);
-    $offset = 0;
-    assert(unpack_u64_dyn_p($enc, $offset) == $val);
-    assert($offset == strlen($enc));
-}
-
-$tests_u64 = [
+$tests = [
     0 => "\x00",
     0x7f => "\x7F",
     0x80 => "\x80\x00",
@@ -44,7 +28,7 @@ $tests_u64 = [
     -1 => "\xFF\xFE\xFE\xFE\xFE\xFE\xFE\xFE\xFE",
     -9223372036854775808 => "\x80\xFF\xFE\xFE\xFE\xFE\xFE\xFE\x7E",
 ];
-foreach ($tests_u64 as $val => $enc)
+foreach ($tests as $val => $enc)
 {
     assert(pack_u64_dyn_b($val) == $enc);
     $offset = 0;
@@ -52,7 +36,23 @@ foreach ($tests_u64 as $val => $enc)
     assert($offset == strlen($enc));
 }
 
-$tests_u64 = [
+$tests = [
+    0 => "\x00",
+    0x7f => "\x7F",
+    0x80 => "\x80\x02",
+    0x4000 => "\xC0\x00\x02",
+    0x123456789ABCDEF => "\xFF\xEF\xCD\xAB\x89\x67\x45\x23\x01",
+    -1 => "\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF",
+];
+foreach ($tests as $val => $enc)
+{
+    assert(pack_u64_dyn_p($val) == $enc);
+    $offset = 0;
+    assert(unpack_u64_dyn_p($enc, $offset) == $val);
+    assert($offset == strlen($enc));
+}
+
+$tests = [
     0 => "\x00",
     0x7f => "\x7F",
     0x80 => "\x80\x00",
@@ -62,7 +62,7 @@ $tests_u64 = [
     -1 => "\xFF\x7F\xBF\xDF\xEF\xF7\xFB\xFD\xFE",
     -9223372036854775808 => "\xFF\x80\xBF\xDF\xEF\xF7\xFB\xFD\x7E",
 ];
-foreach ($tests_u64 as $val => $enc)
+foreach ($tests as $val => $enc)
 {
     assert(pack_u64_dyn_bp($val) == $enc);
     $offset = 0;
@@ -70,7 +70,7 @@ foreach ($tests_u64 as $val => $enc)
     assert($offset == strlen($enc));
 }
 
-$tests_i64 = [
+$tests = [
     0 => "\x00",
     0x7f => "\xBF\x01",
     0x80 => "\x80\x02",
@@ -79,7 +79,7 @@ $tests_i64 = [
     -1 => "\x41",
     PHP_INT_MIN => "\x40",
 ];
-foreach ($tests_i64 as $val => $enc)
+foreach ($tests as $val => $enc)
 {
     assert(pack_i64_dyn_a($val) == $enc);
     $offset = 0;
@@ -87,7 +87,7 @@ foreach ($tests_i64 as $val => $enc)
     assert($offset == strlen($enc));
 }
 
-$tests_i64 = [
+$tests = [
     0 => "\x00",
     0x7f => "\xBF\x00",
     0x80 => "\x80\x01",
@@ -96,7 +96,7 @@ $tests_i64 = [
     -1 => "\x40",
     -9223372036854775808 => "\xFF\xFE\xFE\xFE\xFE\xFE\xFE\xFE\xFE",
 ];
-foreach ($tests_i64 as $val => $enc)
+foreach ($tests as $val => $enc)
 {
     assert(pack_i64_dyn_b($val) == $enc);
     $offset = 0;
@@ -104,7 +104,7 @@ foreach ($tests_i64 as $val => $enc)
     assert($offset == strlen($enc));
 }
 
-$tests_i64 = [
+$tests = [
     0 => "\x00",
     0x7f => "\xBF\x00",
     0x80 => "\x80\x02",
@@ -113,7 +113,7 @@ $tests_i64 = [
     -1 => "\x40",
     -9223372036854775808 => "\xFF\x7F\xBF\xDF\xEF\xF7\xFB\xFD\xFE",
 ];
-foreach ($tests_i64 as $val => $enc)
+foreach ($tests as $val => $enc)
 {
     assert(pack_i64_dyn_bp($val) == $enc);
     $offset = 0;

--- a/php/u64_dyn.php
+++ b/php/u64_dyn.php
@@ -247,12 +247,8 @@ function pack_u64_dyn_bp($v)
 
     $v = add64($v, -get_bias($byte_length));
 
-    $first_byte_mask = $first_byte_value_bits ? (1 << $first_byte_value_bits) - 1 : 0;
-    $first_byte = ((0xff << (8 - $first_byte_prefix_bits)) & 0xff) | ($v & $first_byte_mask);
-    if ($first_byte_value_bits)
-    {
-        $v >>= $first_byte_value_bits;
-    }
+    $first_byte = ((0xff << (8 - $first_byte_prefix_bits)) & 0xff) | ($v & ((1 << $first_byte_value_bits) - 1));
+    $v >>= $first_byte_value_bits;
 
     $out = chr($first_byte);
     for ($idx = 1; $idx < $byte_length; ++$idx)

--- a/php/u64_dyn.php
+++ b/php/u64_dyn.php
@@ -28,6 +28,23 @@ function cmp64($a, $b)
     return $a_lo <=> $b_lo;
 }
 
+function sub64($a, $b)
+{
+    return add64($a, add64(~$b, 1));
+}
+
+function get_bias($byte_length)
+{
+    $bias = 0;
+    while ($byte_length > 1)
+    {
+        $byte_length -= 1;
+        $bias += 1;
+        $bias <<= 7;
+    }
+    return $bias;
+}
+
 function pack_u64_dyn($v)
 {
     if (is_float($v))
@@ -178,6 +195,49 @@ function pack_u64_dyn_b($v)
     return $out;
 }
 
+function pack_u64_dyn_bp($v)
+{
+    if (is_float($v))
+    {
+        throw new Exception("Cannot encode a float as u64");
+    }
+
+    $byte_length = 1;
+    if (cmp64($v, 0x80) >= 0) { $byte_length += 1; }
+    if (cmp64($v, 0x4080) >= 0) { $byte_length += 1; }
+    if (cmp64($v, 0x204080) >= 0) { $byte_length += 1; }
+    if (cmp64($v, 0x10204080) >= 0) { $byte_length += 1; }
+    if (cmp64($v, 0x810204080) >= 0) { $byte_length += 1; }
+    if (cmp64($v, 0x40810204080) >= 0) { $byte_length += 1; }
+    if (cmp64($v, 0x2040810204080) >= 0) { $byte_length += 1; }
+    if (cmp64($v, 0x102040810204080) >= 0) { $byte_length += 1; }
+
+    $first_byte_value_bits = $byte_length < 8 ? 8 - $byte_length : 0;
+    $first_byte_prefix_bits = $byte_length - 1;
+
+    $bias = get_bias($byte_length);
+    if (cmp64($v, $bias) < 0)
+    {
+        throw new Exception("Value too small for biased encoding");
+    }
+    $v = sub64($v, $bias);
+
+    $first_byte_mask = $first_byte_value_bits ? (1 << $first_byte_value_bits) - 1 : 0;
+    $first_byte = ((0xff << (8 - $first_byte_prefix_bits)) & 0xff) | ($v & $first_byte_mask);
+    if ($first_byte_value_bits)
+    {
+        $v >>= $first_byte_value_bits;
+    }
+
+    $out = chr($first_byte);
+    for ($idx = 1; $idx < $byte_length; ++$idx)
+    {
+        $out .= chr(($v >> (($idx - 1) * 8)) & 0xff);
+    }
+
+    return $out;
+}
+
 function unpack_u64_dyn_b($str, &$offset = 0)
 {
     $len = strlen($str);
@@ -211,6 +271,50 @@ function unpack_u64_dyn_b($str, &$offset = 0)
     {
         throw new Exception("Invalid data");
     }
+    return add64($v, $bias);
+}
+
+function unpack_u64_dyn_bp($str, &$offset = 0)
+{
+    $len = strlen($str);
+    if ($offset >= $len)
+    {
+        throw new Exception("Insufficient data");
+    }
+
+    $first_byte = ord($str[$offset]);
+
+    $prefix_bits = 0;
+    while ($prefix_bits < 8 && ($first_byte & (0x80 >> $prefix_bits)) != 0)
+    {
+        $prefix_bits += 1;
+    }
+
+    $byte_length = $prefix_bits + 1;
+    $first_byte_value_bits = $byte_length < 8 ? 8 - $byte_length : 0;
+
+    if ($offset + $byte_length > $len)
+    {
+        throw new Exception("Insufficient data");
+    }
+
+    $v = 0;
+    for ($idx = 1; $idx != $byte_length; ++$idx)
+    {
+        $b = ord($str[$offset + $idx]);
+        $v |= $b << (($idx - 1) * 8);
+    }
+
+    $v <<= $first_byte_value_bits;
+    $v |= $first_byte & ((1 << $first_byte_value_bits) - 1);
+
+    $bias = get_bias($byte_length);
+    if (cmp64($v, sub64(-1, $bias)) > 0)
+    {
+        throw new Exception("Invalid data");
+    }
+
+    $offset += $byte_length;
     return add64($v, $bias);
 }
 
@@ -263,6 +367,34 @@ function pack_i64_dyn_b($v)
 function unpack_i64_dyn_b($str, &$offset = 0)
 {
     $v = unpack_u64_dyn_b($str, $offset);
+    $neg = (($v >> 6) & 1) != 0;
+    $upper = $v & ~0x7f;
+    $upper = ($upper >> 1) & ~(-1 << 63);
+    $v = $upper | ($v & 0x3f);
+    if ($neg)
+    {
+        $v = ~$v;
+    }
+    return $v;
+}
+
+function pack_i64_dyn_bp($v)
+{
+    if (is_float($v))
+    {
+        throw new Exception("Cannot encode a float as i64");
+    }
+    $neg = ($v >> 63) & 1;
+    if ($v < 0)
+    {
+        $v = ~$v;
+    }
+    return pack_u64_dyn_bp(($neg << 6) | (($v & ~0x3f) << 1) | ($v & 0x3f));
+}
+
+function unpack_i64_dyn_bp($str, &$offset = 0)
+{
+    $v = unpack_u64_dyn_bp($str, $offset);
     $neg = (($v >> 6) & 1) != 0;
     $upper = $v & ~0x7f;
     $upper = ($upper >> 1) & ~(-1 << 63);

--- a/php/u64_dyn.php
+++ b/php/u64_dyn.php
@@ -28,11 +28,6 @@ function cmp64($a, $b)
     return $a_lo <=> $b_lo;
 }
 
-function sub64($a, $b)
-{
-    return add64($a, add64(~$b, 1));
-}
-
 function get_bias($byte_length)
 {
     $bias = 0;
@@ -220,7 +215,7 @@ function pack_u64_dyn_bp($v)
     {
         throw new Exception("Value too small for biased encoding");
     }
-    $v = sub64($v, $bias);
+    $v = add64($v, -$bias);
 
     $first_byte_mask = $first_byte_value_bits ? (1 << $first_byte_value_bits) - 1 : 0;
     $first_byte = ((0xff << (8 - $first_byte_prefix_bits)) & 0xff) | ($v & $first_byte_mask);
@@ -309,7 +304,7 @@ function unpack_u64_dyn_bp($str, &$offset = 0)
     $v |= $first_byte & ((1 << $first_byte_value_bits) - 1);
 
     $bias = get_bias($byte_length);
-    if (cmp64($v, sub64(-1, $bias)) > 0)
+    if (cmp64($v, add64(-1, -$bias)) > 0)
     {
         throw new Exception("Invalid data");
     }

--- a/php/u64_dyn.php
+++ b/php/u64_dyn.php
@@ -31,9 +31,8 @@ function cmp64($a, $b)
 function get_bias($byte_length)
 {
     $bias = 0;
-    while ($byte_length > 1)
+    while (--$byte_length)
     {
-        $byte_length -= 1;
         $bias += 1;
         $bias <<= 7;
     }
@@ -210,12 +209,7 @@ function pack_u64_dyn_bp($v)
     $first_byte_value_bits = $byte_length < 8 ? 8 - $byte_length : 0;
     $first_byte_prefix_bits = $byte_length - 1;
 
-    $bias = get_bias($byte_length);
-    if (cmp64($v, $bias) < 0)
-    {
-        throw new Exception("Value too small for biased encoding");
-    }
-    $v = add64($v, -$bias);
+    $v = add64($v, -get_bias($byte_length));
 
     $first_byte_mask = $first_byte_value_bits ? (1 << $first_byte_value_bits) - 1 : 0;
     $first_byte = ((0xff << (8 - $first_byte_prefix_bits)) & 0xff) | ($v & $first_byte_mask);

--- a/php/u64_dyn.php
+++ b/php/u64_dyn.php
@@ -93,6 +93,68 @@ function unpack_u64_dyn($str, &$offset = 0)
     return $v;
 }
 
+function pack_u64_dyn_b($v)
+{
+    if (is_float($v))
+    {
+        throw new Exception("Cannot encode a float as u64");
+    }
+    $out = "";
+    for ($i = 0; $i != 8; ++$i)
+    {
+        $cur = $v & 0x7f;
+        $v >>= 7;
+        if ($v != 0)
+        {
+            $out .= chr($cur | 0x80);
+            $v -= 1; // bias
+        }
+        else
+        {
+            $out .= chr($cur);
+            return $out;
+        }
+    }
+    $out .= chr($v);
+    return $out;
+}
+
+function unpack_u64_dyn_b($str, &$offset = 0)
+{
+    $len = strlen($str);
+    $v = 0;
+    $bits = 0;
+    $i = $offset;
+    $bias = 0;
+    while (true)
+    {
+        if ($i >= $len)
+        {
+            throw new Exception("Insufficient data");
+        }
+        $b = ord($str[$i]);
+        $i++;
+        if ($i - $offset == 9)
+        {
+            $v = add64($v, $b << 56);
+            break;
+        }
+        $v = add64($v, ($b & 0x7f) << $bits);
+        if (($b & 0x80) == 0)
+        {
+            break;
+        }
+        $bits += 7;
+        $bias = add64($bias, 1 << $bits);
+    }
+    $offset = $i;
+    if (cmp64($v, add64(-1, -$bias)) > 0)
+    {
+        throw new Exception("Invalid data");
+    }
+    return add64($v, $bias);
+}
+
 function pack_u64_dyn_p($v)
 {
     if (is_float($v))
@@ -163,32 +225,6 @@ function unpack_u64_dyn_p($str, &$offset = 0)
     return $v;
 }
 
-function pack_u64_dyn_b($v)
-{
-    if (is_float($v))
-    {
-        throw new Exception("Cannot encode a float as u64");
-    }
-    $out = "";
-    for ($i = 0; $i != 8; ++$i)
-    {
-        $cur = $v & 0x7f;
-        $v >>= 7;
-        if ($v != 0)
-        {
-            $out .= chr($cur | 0x80);
-            $v -= 1; // bias
-        }
-        else
-        {
-            $out .= chr($cur);
-            return $out;
-        }
-    }
-    $out .= chr($v);
-    return $out;
-}
-
 function pack_u64_dyn_bp($v)
 {
     if (is_float($v))
@@ -225,42 +261,6 @@ function pack_u64_dyn_bp($v)
     }
 
     return $out;
-}
-
-function unpack_u64_dyn_b($str, &$offset = 0)
-{
-    $len = strlen($str);
-    $v = 0;
-    $bits = 0;
-    $i = $offset;
-    $bias = 0;
-    while (true)
-    {
-        if ($i >= $len)
-        {
-            throw new Exception("Insufficient data");
-        }
-        $b = ord($str[$i]);
-        $i++;
-        if ($i - $offset == 9)
-        {
-            $v = add64($v, $b << 56);
-            break;
-        }
-        $v = add64($v, ($b & 0x7f) << $bits);
-        if (($b & 0x80) == 0)
-        {
-            break;
-        }
-        $bits += 7;
-        $bias = add64($bias, 1 << $bits);
-    }
-    $offset = $i;
-    if (cmp64($v, add64(-1, -$bias)) > 0)
-    {
-        throw new Exception("Invalid data");
-    }
-    return add64($v, $bias);
 }
 
 function unpack_u64_dyn_bp($str, &$offset = 0)


### PR DESCRIPTION
## Summary
- add helper routines and biased-prefix pack/unpack implementations to the PHP codec
- extend the PHP test suite to cover biased-prefix unsigned and signed encoders and decoders
- add regression coverage for invalid biased-prefix payloads

## Testing
- php php/test.php

------
https://chatgpt.com/codex/tasks/task_e_69022c05e10083258555b41fa4f495f3