### PR TITLE
[Lua] Implement i64_dyn_bp

### DIFF
--- a/lua/test.lua
+++ b/lua/test.lua
@@ -83,6 +83,19 @@ for val, enc in pairs({
     assert(unpack_i64_dyn_b(enc) == val)
 end
 
+for val, enc in pairs({
+    [0] = "\x00",
+    [0x7f] = "\xBF\x00",
+    [0x80] = "\x80\x02",
+    [1337] = "\xB9\x26",
+    [42069] = "\xD5\x40\x08",
+    [-1] = "\x40",
+    [-9223372036854775808] = "\xFF\x7F\xBF\xDF\xEF\xF7\xFB\xFD\xFE",
+}) do
+    assert(pack_i64_dyn_bp(val) == enc)
+    assert(unpack_i64_dyn_bp(enc) == val)
+end
+
 for _, enc in pairs({ "", "\x80", "\x80\x80\x80\x80\x80\x80\x80\x80" }) do
     assert(not pcall(unpack_u64_dyn, enc))
     assert(not pcall(unpack_i64_dyn_a, enc))
@@ -100,4 +113,5 @@ do
     assert(not pcall(unpack_u64_dyn_b, enc))
     assert(not pcall(unpack_u64_dyn_bp, enc))
     assert(not pcall(unpack_i64_dyn_b, enc))
+    assert(not pcall(unpack_i64_dyn_bp, enc))
 end

--- a/lua/u64_dyn.lua
+++ b/lua/u64_dyn.lua
@@ -219,6 +219,25 @@ function unpack_i64_dyn_b(str, i)
     return v, i
 end
 
+function pack_i64_dyn_bp(v)
+    local neg = (v >> 63)
+    if v < 0 then
+        v = ~v
+    end
+    return pack_u64_dyn_bp((neg << 6) | ((v & ~0x3f) << 1) | (v & 0x3f))
+end
+
+function unpack_i64_dyn_bp(str, i)
+    local v
+    v, i = unpack_u64_dyn_bp(str, i)
+    local neg = ((v >> 6) & 1) ~= 0
+    v = ((v >> 1) & ~0x3f) | (v & 0x3f)
+    if neg then
+        v = ~v
+    end
+    return v, i
+end
+
 function pack_i64_dyn(v)
     if warn then
         warn("unpack_u64_dyn_b: renamed to pack_i64_dyn_a")


### PR DESCRIPTION
## Summary
- add Lua implementations of the bias-preserving i64 encoder/decoder by reusing the u64 helpers
- extend the Lua test suite with coverage for the new routines and corresponding failure cases

## Testing
- LUA_PATH="./lua/?.lua;;" lua lua/test.lua

------
https://chatgpt.com/codex/tasks/task_e_69023f959a70832586c7c75ea6550105