### PR TITLE
Implement i64_dyn_p where it's still missing

### DIFF
--- a/c/test.c
+++ b/c/test.c
@@ -129,6 +129,27 @@ int main() {
   {
     struct IPair pairs[] = {
         {0, "\x00", 1},
+        {0x7f, "\xBF\x02", 2},
+        {0x80, "\x80\x04", 2},
+        {1337, "\xB9\x28", 2},
+        {42069, "\xD5\x44\x0A", 3},
+        {-1, "\x40", 1},
+        {INT64_MIN, "\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF", 9},
+    };
+    for (size_t i = 0; i != COUNT(pairs); ++i) {
+      const struct IPair *pair = &pairs[i];
+      assert(pack_i64_dyn_p(data, pair->v) == pair->s);
+      assert(memcmp(data, pair->d, pair->s) == 0);
+      int64_t out_v;
+      assert(unpack_i64_dyn_p(data, pair->s, &out_v, &out_size));
+      assert(out_v == pair->v);
+      assert(out_size == pair->s);
+    }
+  }
+
+  {
+    struct IPair pairs[] = {
+        {0, "\x00", 1},
         {0x7f, "\xBF\x00", 2},
         {0x80, "\x80\x01", 2},
         {1337, "\xB9\x13", 2},
@@ -207,6 +228,7 @@ int main() {
       size_t used;
       assert(!unpack_u64_dyn_p(bads[i].d, bads[i].s, &u, &used));
       assert(!unpack_u64_dyn_bp(bads[i].d, bads[i].s, &u, &used));
+      assert(!unpack_i64_dyn_p(bads[i].d, bads[i].s, &v, &used));
       assert(!unpack_i64_dyn_bp(bads[i].d, bads[i].s, &v, &used));
     }
   }

--- a/c/u64_dyn.c
+++ b/c/u64_dyn.c
@@ -282,6 +282,28 @@ bool unpack_i64_dyn_b(const uint8_t *in_data, size_t in_size, int64_t *out_v,
   return true;
 }
 
+size_t pack_i64_dyn_p(uint8_t out[9], int64_t v) {
+  uint64_t neg = (uint64_t)(v < 0);
+  uint64_t u = (uint64_t)v ^ (0xffffffffffffffffULL * neg);
+  return pack_u64_dyn_p(out,
+                        (neg << 6) | ((u & ~0x3fULL) << 1) | (u & 0x3fULL));
+}
+
+bool unpack_i64_dyn_p(const uint8_t *in_data, size_t in_size, int64_t *out_v,
+                      size_t *out_size) {
+  uint64_t u;
+  if (!unpack_u64_dyn_p(in_data, in_size, &u, out_size)) {
+    return false;
+  }
+  const uint64_t neg = (u >> 6) & 1;
+  u = ((u >> 1) & ~0x3fULL) | (u & 0x3fULL);
+  int64_t v = (int64_t)(u ^ (0xffffffffffffffffULL * neg));
+  if (out_v) {
+    *out_v = v;
+  }
+  return true;
+}
+
 size_t pack_i64_dyn_bp(uint8_t out[9], int64_t v) {
   uint64_t neg = (uint64_t)(v < 0);
   uint64_t u = v ^ (0xffffffffffffffff * neg);

--- a/c/u64_dyn.h
+++ b/c/u64_dyn.h
@@ -5,6 +5,10 @@
 #include <stddef.h> // size_t
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 size_t pack_u64_dyn(uint8_t out[9], uint64_t v);
 bool unpack_u64_dyn(const uint8_t *in_data, size_t in_size, uint64_t *out_v,
                     size_t *out_size);
@@ -27,6 +31,10 @@ bool unpack_i64_dyn_a(const uint8_t *in_data, size_t in_size, int64_t *out_v,
 
 size_t pack_i64_dyn_b(uint8_t out[9], int64_t v);
 bool unpack_i64_dyn_b(const uint8_t *in_data, size_t in_size, int64_t *out_v,
+                      size_t *out_size);
+
+size_t pack_i64_dyn_p(uint8_t out[9], int64_t v);
+bool unpack_i64_dyn_p(const uint8_t *in_data, size_t in_size, int64_t *out_v,
                       size_t *out_size);
 
 size_t pack_i64_dyn_bp(uint8_t out[9], int64_t v);
@@ -53,5 +61,9 @@ size_t pack_i64_dyn_v2(uint8_t out[9], int64_t v);
 // Renamed to unpack_i64_dyn_b
 bool unpack_i64_dyn_v2(const uint8_t *in_data, size_t in_size, int64_t *out_v,
                        size_t *out_size);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/js/test.js
+++ b/js/test.js
@@ -142,7 +142,6 @@ for (const [val, enc] of casesI64b) {
   );
 }
 
-
 const casesI64p = new Map([
   [0n, [0x00]],
   [0x7fn, [0xbf, 0x02]],

--- a/js/test.js
+++ b/js/test.js
@@ -12,6 +12,8 @@ const {
   unpack_i64_dyn_a,
   pack_i64_dyn_b,
   unpack_i64_dyn_b,
+  pack_i64_dyn_p,
+  unpack_i64_dyn_p,
   pack_i64_dyn_bp,
   unpack_i64_dyn_bp,
 } = require("./u64_dyn");
@@ -140,6 +142,30 @@ for (const [val, enc] of casesI64b) {
   );
 }
 
+
+const casesI64p = new Map([
+  [0n, [0x00]],
+  [0x7fn, [0xbf, 0x02]],
+  [0x80n, [0x80, 0x04]],
+  [1337n, [0xb9, 0x28]],
+  [42069n, [0xd5, 0x44, 0x0a]],
+  [-1n, [0x40]],
+  [
+    -9223372036854775808n,
+    [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
+  ],
+]);
+for (const [val, enc] of casesI64p) {
+  const packed = Array.from(pack_i64_dyn_p(val));
+  assert.deepStrictEqual(packed, enc, `pack_i64_dyn_p mismatch for ${val}`);
+  const [value, off] = unpack_i64_dyn_p(Uint8Array.from(enc));
+  assert.deepStrictEqual(
+    [value, off],
+    [val, enc.length],
+    `unpack_i64_dyn_p mismatch for ${val}`,
+  );
+}
+
 const casesI64bp = new Map([
   [0n, [0x00]],
   [0x7fn, [0xbf, 0x00]],
@@ -212,6 +238,10 @@ for (const enc of truncatedCasesP) {
   expectThrow(
     () => unpack_u64_dyn_bp(buf),
     "unpack_u64_dyn_bp should throw on insufficient data",
+  );
+  expectThrow(
+    () => unpack_i64_dyn_p(buf),
+    "unpack_i64_dyn_p should throw on insufficient data",
   );
   expectThrow(
     () => unpack_i64_dyn_bp(buf),

--- a/js/u64_dyn.d.ts
+++ b/js/u64_dyn.d.ts
@@ -34,6 +34,11 @@ export function unpack_i64_dyn_b(
   offset?: number,
 ): [bigint, number];
 
+export function pack_i64_dyn_p(value: bigint | number): Uint8Array;
+export function unpack_i64_dyn_p(
+  data: Uint8Array,
+  offset?: number,
+): [bigint, number];
 export function pack_i64_dyn_bp(value: bigint | number): Uint8Array;
 export function unpack_i64_dyn_bp(
   data: Uint8Array,

--- a/js/u64_dyn.d.ts
+++ b/js/u64_dyn.d.ts
@@ -39,6 +39,7 @@ export function unpack_i64_dyn_p(
   data: Uint8Array,
   offset?: number,
 ): [bigint, number];
+
 export function pack_i64_dyn_bp(value: bigint | number): Uint8Array;
 export function unpack_i64_dyn_bp(
   data: Uint8Array,

--- a/js/u64_dyn.js
+++ b/js/u64_dyn.js
@@ -229,24 +229,14 @@ function unpack_i64_dyn_b(buf, offset = 0) {
   let u = u64;
   const neg = (u >> 6n) & 1n;
   u = ((u >> 1n) & ~0x3fn) | (u & 0x3fn);
-  let v;
-  if (neg) {
-    v = ~u;
-  } else {
-    v = u;
-  }
+  const v = neg ? ~u : u;
   return [v, idx];
 }
 
 function pack_i64_dyn_p(v) {
   if (typeof v !== "bigint") v = BigInt(v);
   const neg = v < 0n ? 1n : 0n;
-  let u;
-  if (neg) {
-    u = ~v;
-  } else {
-    u = v;
-  }
+  const u = neg ? ~v : v;
   const packed = (neg << 6n) | ((u & ~0x3fn) << 1n) | (u & 0x3fn);
   return pack_u64_dyn_p(packed);
 }
@@ -256,24 +246,14 @@ function unpack_i64_dyn_p(buf, offset = 0) {
   let u = u64;
   const neg = (u >> 6n) & 1n;
   u = ((u >> 1n) & ~0x3fn) | (u & 0x3fn);
-  let v;
-  if (neg) {
-    v = ~u;
-  } else {
-    v = u;
-  }
+  const v = neg ? ~u : u;
   return [v, idx];
 }
 
 function pack_i64_dyn_bp(v) {
   if (typeof v !== "bigint") v = BigInt(v);
   const neg = v < 0n ? 1n : 0n;
-  let u;
-  if (neg) {
-    u = ~v;
-  } else {
-    u = v;
-  }
+  const u = neg ? ~v : v;
   const packed = (neg << 6n) | ((u & ~0x3fn) << 1n) | (u & 0x3fn);
   return pack_u64_dyn_bp(packed);
 }
@@ -283,12 +263,7 @@ function unpack_i64_dyn_bp(buf, offset = 0) {
   let u = u64;
   const neg = (u >> 6n) & 1n;
   u = ((u >> 1n) & ~0x3fn) | (u & 0x3fn);
-  let v;
-  if (neg) {
-    v = ~u;
-  } else {
-    v = u;
-  }
+  const v = neg ? ~u : u;
   return [v, idx];
 }
 

--- a/js/u64_dyn.js
+++ b/js/u64_dyn.js
@@ -238,6 +238,33 @@ function unpack_i64_dyn_b(buf, offset = 0) {
   return [v, idx];
 }
 
+function pack_i64_dyn_p(v) {
+  if (typeof v !== "bigint") v = BigInt(v);
+  const neg = v < 0n ? 1n : 0n;
+  let u;
+  if (neg) {
+    u = ~v;
+  } else {
+    u = v;
+  }
+  const packed = (neg << 6n) | ((u & ~0x3fn) << 1n) | (u & 0x3fn);
+  return pack_u64_dyn_p(packed);
+}
+
+function unpack_i64_dyn_p(buf, offset = 0) {
+  const [u64, idx] = unpack_u64_dyn_p(buf, offset);
+  let u = u64;
+  const neg = (u >> 6n) & 1n;
+  u = ((u >> 1n) & ~0x3fn) | (u & 0x3fn);
+  let v;
+  if (neg) {
+    v = ~u;
+  } else {
+    v = u;
+  }
+  return [v, idx];
+}
+
 function pack_i64_dyn_bp(v) {
   if (typeof v !== "bigint") v = BigInt(v);
   const neg = v < 0n ? 1n : 0n;
@@ -302,6 +329,8 @@ module.exports = {
   unpack_i64_dyn_a,
   pack_i64_dyn_b,
   unpack_i64_dyn_b,
+  pack_i64_dyn_p,
+  unpack_i64_dyn_p,
   pack_i64_dyn_bp,
   unpack_i64_dyn_bp,
   pack_u64_dyn_v2,

--- a/php/test.php
+++ b/php/test.php
@@ -87,6 +87,24 @@ foreach ($tests as $val => $enc)
     assert($offset == strlen($enc));
 }
 
+
+$tests = [
+    0 => "\x00",
+    0x7f => "\xBF\x02",
+    0x80 => "\x80\x04",
+    1337 => "\xB9\x28",
+    42069 => "\xD5\x44\x0A",
+    -1 => "\x40",
+    -9223372036854775808 => "\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF",
+];
+foreach ($tests as $val => $enc)
+{
+    assert(pack_i64_dyn_p($val) == $enc);
+    $offset = 0;
+    assert(unpack_i64_dyn_p($enc, $offset) == $val);
+    assert($offset == strlen($enc));
+}
+
 $tests = [
     0 => "\x00",
     0x7f => "\xBF\x00",
@@ -161,6 +179,12 @@ foreach ($incomplete_p as $enc)
     try {
         $offset = 0;
         unpack_u64_dyn_bp($enc, $offset);
+        assert(false);
+    } catch (Exception $e) {}
+
+    try {
+        $offset = 0;
+        unpack_i64_dyn_p($enc, $offset);
         assert(false);
     } catch (Exception $e) {}
 

--- a/php/u64_dyn.php
+++ b/php/u64_dyn.php
@@ -363,6 +363,34 @@ function unpack_i64_dyn_b($str, &$offset = 0)
     return $v;
 }
 
+function pack_i64_dyn_p($v)
+{
+    if (is_float($v))
+    {
+        throw new Exception("Cannot encode a float as i64");
+    }
+    $neg = ($v >> 63) & 1;
+    if ($v < 0)
+    {
+        $v = ~$v;
+    }
+    return pack_u64_dyn_p(($neg << 6) | (($v & ~0x3f) << 1) | ($v & 0x3f));
+}
+
+function unpack_i64_dyn_p($str, &$offset = 0)
+{
+    $v = unpack_u64_dyn_p($str, $offset);
+    $neg = (($v >> 6) & 1) != 0;
+    $upper = $v & ~0x7f;
+    $upper = ($upper >> 1) & ~(-1 << 63);
+    $v = $upper | ($v & 0x3f);
+    if ($neg)
+    {
+        $v = ~$v;
+    }
+    return $v;
+}
+
 function pack_i64_dyn_bp($v)
 {
     if (is_float($v))

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -238,6 +238,27 @@ pub fn unpack_i64_dyn_b(data: &[u8]) -> Option<(i64, usize)> {
     Some((v, used))
 }
 
+pub fn pack_i64_dyn_p(v: i64) -> Vec<u8> {
+    let mut u = v as u64;
+    let neg = (v < 0) as u64;
+    if neg != 0 {
+        u = !u;
+    }
+    let packed = (neg << 6) | ((u & !0x3f) << 1) | (u & 0x3f);
+    pack_u64_dyn_p(packed)
+}
+
+pub fn unpack_i64_dyn_p(data: &[u8]) -> Option<(i64, usize)> {
+    let (mut u, used) = unpack_u64_dyn_p(data)?;
+    let neg = (u >> 6) & 1;
+    u = ((u >> 1) & !0x3f) | (u & 0x3f);
+    let mut v = u as i64;
+    if neg != 0 {
+        v = !v;
+    }
+    Some((v, used))
+}
+
 pub fn pack_i64_dyn_bp(v: i64) -> Vec<u8> {
     let mut u = v as u64;
     let neg = (v < 0) as u64;

--- a/rust/tests.rs
+++ b/rust/tests.rs
@@ -103,6 +103,24 @@ fn test_i64_dyn_b() {
     }
 }
 
+
+#[test]
+fn test_i64_dyn_p() {
+    let cases = [
+        (0i64, vec![0x00]),
+        (0x7f, vec![0xbf, 0x02]),
+        (0x80, vec![0x80, 0x04]),
+        (1337, vec![0xb9, 0x28]),
+        (42069, vec![0xd5, 0x44, 0x0a]),
+        (-1, vec![0x40]),
+        (i64::MIN, vec![0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]),
+    ];
+    for (val, enc) in cases {
+        assert_eq!(pack_i64_dyn_p(val), enc);
+        assert_eq!(unpack_i64_dyn_p(&enc), Some((val, enc.len())));
+    }
+}
+
 #[test]
 fn test_i64_dyn_bp() {
     let cases = [
@@ -145,6 +163,7 @@ fn test_truncated_p() {
     for enc in truncated {
         assert!(unpack_u64_dyn_p(&enc).is_none());
         assert!(unpack_u64_dyn_bp(&enc).is_none());
+        assert!(unpack_i64_dyn_p(&enc).is_none());
         assert!(unpack_i64_dyn_bp(&enc).is_none());
     }
 }


### PR DESCRIPTION
### Motivation
- Add missing `i64_dyn_p` pack/unpack variants to match the existing `u64_dyn_p` behavior and the Lua reference implementation across all language bindings. 

### Description
- Add `pack_i64_dyn_p` and `unpack_i64_dyn_p` declarations to `c/u64_dyn.h` and guard the header with `extern "C"` for C++ consumers. 
- Implement `pack_i64_dyn_p` / `unpack_i64_dyn_p` in `c/u64_dyn.c` by delegating to the `u64_dyn_p` encoders/decoders with the same sign/bit manipulation used by other `i64` variants. 
- Export `pack_i64_dyn_p` / `unpack_i64_dyn_p` in `js/u64_dyn.js` and add corresponding TypeScript declarations in `js/u64_dyn.d.ts`. 
- Implement `pack_i64_dyn_p` / `unpack_i64_dyn_p` in `php/u64_dyn.php` and `rust/lib.rs` following the same conversion logic and delegating to `u64_dyn_p`. 
- Extend tests in `c/test.c`, `js/test.js`, `php/test.php`, and `rust/tests.rs` to include round-trip cases for `i64_dyn_p` and to assert correct handling of truncated/invalid prefixed inputs. 

### Testing
- Built and ran the C tests with `cc -std=c99 -Wall -Wextra -pedantic c/u64_dyn.c c/test.c` and executed the produced test binary; tests passed. 
- Verified C++ linkage by compiling a small C++ test that calls `pack_i64_dyn_p` / `unpack_i64_dyn_p`; it ran successfully. 
- Ran JavaScript tests with `node js/test.js`; all assertions passed. 
- Ran PHP tests with `php -d zend.assertions=1 -d assert.exception=1 php/test.php`; all assertions passed. 
- Ran Rust tests with `cargo test --manifest-path rust/Cargo.toml`; all unit tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6119cd53b08325a6bf6545e5a395b3)